### PR TITLE
Detect environment (client/server)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -64,5 +64,8 @@
   "version-downgrade-solution": "Install a newer version of Minecraft.",
   "generate-new-world-solution": "Generate a new world.",
   "bedrock-dbstorage-chain-problem": "Unable to decrypt world. Marketplace worlds can't be installed on dedicated servers.",
-  "mod-incompatible-problem": "The mods '{{first-mod-name}}' and '{{second-mod-name}}' are incompatible."
+  "mod-incompatible-problem": "The mods '{{first-mod-name}}' and '{{second-mod-name}}' are incompatible.",
+  "environment": "Environment",
+  "environment-client": "Client",
+  "environment-server": "Server"
 }

--- a/src/Analyser/VanillaAnalyser.php
+++ b/src/Analyser/VanillaAnalyser.php
@@ -2,6 +2,7 @@
 
 namespace Aternos\Codex\Minecraft\Analyser;
 
+use Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation;
 use Aternos\Codex\Minecraft\Analysis\Information\Vanilla\VanillaVersionInformation;
 use Aternos\Codex\Minecraft\Analysis\Problem\Vanilla\AquaticWorldOnOlderVersionProblem;
 use Aternos\Codex\Minecraft\Analysis\Problem\Vanilla\MalformedEncodingProblem;
@@ -18,6 +19,7 @@ class VanillaAnalyser extends MinecraftAnalyser
     public function __construct()
     {
         $this->addPossibleInsightClass(VanillaVersionInformation::class);
+        $this->addPossibleInsightClass(EnvironmentInformation::class);
 
         $this->addPossibleInsightClass(OldPlayerDirectoryProblem::class);
         $this->addPossibleInsightClass(AquaticWorldOnOlderVersionProblem::class);

--- a/src/Analysis/Information/Vanilla/EnvironmentInformation.php
+++ b/src/Analysis/Information/Vanilla/EnvironmentInformation.php
@@ -45,4 +45,9 @@ class EnvironmentInformation extends VanillaInformation
                 break;
         }
     }
+
+    public function isEqual($insight): bool
+    {
+        return true;
+    }
 }

--- a/src/Analysis/Information/Vanilla/EnvironmentInformation.php
+++ b/src/Analysis/Information/Vanilla/EnvironmentInformation.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Aternos\Codex\Minecraft\Analysis\Information\Vanilla;
+
+use Aternos\Codex\Minecraft\Log\VanillaLog;
+use Aternos\Codex\Minecraft\Translator\Translator;
+
+/**
+ * Class EnvironmentInformation
+ *
+ * @package Aternos\Codex\Minecraft\Analysis\Information\Vanilla
+ */
+class EnvironmentInformation extends VanillaInformation
+{
+
+    /**
+     * VanillaVersionInformation constructor.
+     */
+    public function __construct()
+    {
+        $this->label = Translator::getInstance()->getTranslation("environment");
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getPatterns(): array
+    {
+        return [
+            "client-thread" => "/^\[(?:[0-9]{2}\:?){3}\] \[Render thread/",
+            "server-thread" => "/^\[(?:[0-9]{2}\:?){3}\] \[Server thread/",
+            "server-failed-to-start" => "/" . VanillaLog::getPrefixPattern() . "Failed to start the minecraft server/",
+        ];
+    }
+
+    public function setMatches(array $matches, $patternKey): void
+    {
+        switch (substr($patternKey, 0, 6)) {
+            case "server":
+                $this->value = Translator::getInstance()->getTranslation("environment-server");
+                break;
+
+            case "client":
+                $this->value = Translator::getInstance()->getTranslation("environment-client");
+                break;
+        }
+    }
+}

--- a/test/data/vanilla/client-singleplayer.log
+++ b/test/data/vanilla/client-singleplayer.log
@@ -1,0 +1,64 @@
+[23:53:36] [Render thread/INFO]: Environment: authHost='https://authserver.mojang.com', accountsHost='https://api.mojang.com', sessionHost='https://sessionserver.mojang.com', servicesHost='https://api.minecraftservices.com', name='PROD'
+[23:53:37] [Render thread/INFO]: Setting user: JulianVennen
+[23:53:38] [Render thread/WARN]: Invalid floating point value for option textBackgroundOpacity = 
+java.lang.NumberFormatException: empty String
+	at jdk.internal.math.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:1842) ~[?:?]
+	at jdk.internal.math.FloatingDecimal.parseDouble(FloatingDecimal.java:110) ~[?:?]
+	at java.lang.Double.parseDouble(Double.java:651) ~[?:?]
+	at dyv$2.a(SourceFile:429) [1.18.2.jar:?]
+	at dyv.a(SourceFile:304) [1.18.2.jar:?]
+	at dyv.a(SourceFile:387) [1.18.2.jar:?]
+	at dyv.<init>(SourceFile:236) [1.18.2.jar:?]
+	at dyr.<init>(SourceFile:454) [1.18.2.jar:?]
+	at net.minecraft.client.main.Main.main(SourceFile:197) [1.18.2.jar:?]
+[23:53:38] [Render thread/INFO]: Backend library: LWJGL version 3.2.2 build 10
+[23:53:39] [Render thread/INFO]: Reloading ResourceManager: Default
+[23:53:44] [Render thread/INFO]: OpenAL initialized on device SteelSeries Arctis 7 Game
+[23:53:44] [Render thread/INFO]: Sound engine started
+[23:53:45] [Render thread/INFO]: Created: 1024x1024x4 minecraft:textures/atlas/blocks.png-atlas
+[23:53:45] [Render thread/INFO]: Created: 256x128x4 minecraft:textures/atlas/signs.png-atlas
+[23:53:45] [Render thread/INFO]: Created: 1024x512x4 minecraft:textures/atlas/banner_patterns.png-atlas
+[23:53:45] [Render thread/INFO]: Created: 1024x512x4 minecraft:textures/atlas/shield_patterns.png-atlas
+[23:53:45] [Render thread/INFO]: Created: 256x256x4 minecraft:textures/atlas/chest.png-atlas
+[23:53:45] [Render thread/INFO]: Created: 512x256x4 minecraft:textures/atlas/beds.png-atlas
+[23:53:45] [Render thread/INFO]: Created: 512x256x4 minecraft:textures/atlas/shulker_boxes.png-atlas
+[23:53:46] [Render thread/INFO]: Created: 256x256x0 minecraft:textures/atlas/particles.png-atlas
+[23:53:47] [Render thread/INFO]: Created: 256x256x0 minecraft:textures/atlas/paintings.png-atlas
+[23:53:47] [Render thread/INFO]: Created: 256x128x0 minecraft:textures/atlas/mob_effects.png-atlas
+[23:54:05] [Render thread/WARN]: Ambiguity between arguments [teleport, location] and [teleport, destination] with inputs: [0.1 -0.5 .9, 0 0 0]
+[23:54:05] [Render thread/WARN]: Ambiguity between arguments [teleport, location] and [teleport, targets] with inputs: [0.1 -0.5 .9, 0 0 0]
+[23:54:05] [Render thread/WARN]: Ambiguity between arguments [teleport, destination] and [teleport, targets] with inputs: [Player, 0123, @e, dd12be42-52a9-4a91-a8a1-11c01849e498]
+[23:54:05] [Render thread/WARN]: Ambiguity between arguments [teleport, targets] and [teleport, destination] with inputs: [Player, 0123, dd12be42-52a9-4a91-a8a1-11c01849e498]
+[23:54:05] [Render thread/WARN]: Ambiguity between arguments [teleport, targets, location] and [teleport, targets, destination] with inputs: [0.1 -0.5 .9, 0 0 0]
+[23:54:05] [Render thread/INFO]: Loaded 7 recipes
+[23:54:05] [Render thread/INFO]: Loaded 1141 advancements
+[23:54:06] [Render thread/INFO]: Environment: authHost='https://authserver.mojang.com', accountsHost='https://api.mojang.com', sessionHost='https://sessionserver.mojang.com', servicesHost='https://api.minecraftservices.com', name='PROD'
+[23:54:06] [Server thread/INFO]: Starting integrated minecraft server version 1.18.2
+[23:54:06] [Server thread/INFO]: Generating keypair
+[23:54:15] [Server thread/INFO]: Preparing start region for dimension minecraft:overworld
+[23:54:16] [Render thread/INFO]: Preparing spawn area: 0%
+[23:54:35] [Render thread/INFO]: Preparing spawn area: 96%
+[23:54:36] [Render thread/INFO]: Time elapsed: 20866 ms
+[23:54:36] [Server thread/INFO]: Changing view distance to 12, from 10
+[23:54:36] [Server thread/INFO]: Changing simulation distance to 12, from 0
+[23:54:36] [Server thread/INFO]: JulianVennen[local:E:b0f3fc68] logged in with entity id 100 at (-137.5, 76.0, 153.5)
+[23:54:36] [Server thread/INFO]: JulianVennen joined the game
+[23:54:36] [Render thread/INFO]: Loaded 0 advancements
+[23:54:40] [Server thread/INFO]: Saving and pausing game...
+[23:54:40] [Server thread/INFO]: Saving chunks for level 'ServerLevel[New World]'/minecraft:overworld
+[23:54:41] [Server thread/INFO]: Saving chunks for level 'ServerLevel[New World]'/minecraft:the_nether
+[23:54:41] [Server thread/INFO]: Saving chunks for level 'ServerLevel[New World]'/minecraft:the_end
+[23:54:41] [Server thread/INFO]: JulianVennen lost connection: Disconnected
+[23:54:41] [Server thread/INFO]: JulianVennen left the game
+[23:54:41] [Server thread/INFO]: Stopping singleplayer server as player logged out
+[23:54:41] [Server thread/INFO]: Stopping server
+[23:54:41] [Server thread/INFO]: Saving players
+[23:54:41] [Server thread/INFO]: Saving worlds
+[23:54:42] [Server thread/INFO]: Saving chunks for level 'ServerLevel[New World]'/minecraft:overworld
+[23:54:42] [Server thread/INFO]: Saving chunks for level 'ServerLevel[New World]'/minecraft:the_nether
+[23:54:42] [Server thread/INFO]: Saving chunks for level 'ServerLevel[New World]'/minecraft:the_end
+[23:54:42] [Server thread/INFO]: ThreadedAnvilChunkStorage (New World): All chunks are saved
+[23:54:42] [Server thread/INFO]: ThreadedAnvilChunkStorage (DIM-1): All chunks are saved
+[23:54:42] [Server thread/INFO]: ThreadedAnvilChunkStorage (DIM1): All chunks are saved
+[23:54:42] [Server thread/INFO]: ThreadedAnvilChunkStorage: All dimensions are saved
+[23:54:43] [Render thread/INFO]: Stopping!

--- a/test/data/vanilla/client.log
+++ b/test/data/vanilla/client.log
@@ -1,0 +1,28 @@
+[23:50:45] [Render thread/INFO]: Environment: authHost='https://authserver.mojang.com', accountsHost='https://api.mojang.com', sessionHost='https://sessionserver.mojang.com', servicesHost='https://api.minecraftservices.com', name='PROD'
+[23:50:45] [Render thread/INFO]: Setting user: JulianVennen
+[23:50:46] [Render thread/WARN]: Invalid floating point value for option textBackgroundOpacity = 
+java.lang.NumberFormatException: empty String
+	at jdk.internal.math.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:1842) ~[?:?]
+	at jdk.internal.math.FloatingDecimal.parseDouble(FloatingDecimal.java:110) ~[?:?]
+	at java.lang.Double.parseDouble(Double.java:651) ~[?:?]
+	at dyv$2.a(SourceFile:429) [1.18.2.jar:?]
+	at dyv.a(SourceFile:304) [1.18.2.jar:?]
+	at dyv.a(SourceFile:387) [1.18.2.jar:?]
+	at dyv.<init>(SourceFile:236) [1.18.2.jar:?]
+	at dyr.<init>(SourceFile:454) [1.18.2.jar:?]
+	at net.minecraft.client.main.Main.main(SourceFile:197) [1.18.2.jar:?]
+[23:50:46] [Render thread/INFO]: Backend library: LWJGL version 3.2.2 build 10
+[23:50:47] [Render thread/INFO]: Reloading ResourceManager: Default
+[23:50:52] [Render thread/INFO]: OpenAL initialized on device SteelSeries Arctis 7 Game
+[23:50:52] [Render thread/INFO]: Sound engine started
+[23:50:53] [Render thread/INFO]: Created: 1024x1024x4 minecraft:textures/atlas/blocks.png-atlas
+[23:50:53] [Render thread/INFO]: Created: 256x128x4 minecraft:textures/atlas/signs.png-atlas
+[23:50:53] [Render thread/INFO]: Created: 1024x512x4 minecraft:textures/atlas/banner_patterns.png-atlas
+[23:50:53] [Render thread/INFO]: Created: 1024x512x4 minecraft:textures/atlas/shield_patterns.png-atlas
+[23:50:53] [Render thread/INFO]: Created: 256x256x4 minecraft:textures/atlas/chest.png-atlas
+[23:50:53] [Render thread/INFO]: Created: 512x256x4 minecraft:textures/atlas/beds.png-atlas
+[23:50:53] [Render thread/INFO]: Created: 512x256x4 minecraft:textures/atlas/shulker_boxes.png-atlas
+[23:50:55] [Render thread/INFO]: Created: 256x256x0 minecraft:textures/atlas/particles.png-atlas
+[23:50:55] [Render thread/INFO]: Created: 256x256x0 minecraft:textures/atlas/paintings.png-atlas
+[23:50:55] [Render thread/INFO]: Created: 256x128x0 minecraft:textures/atlas/mob_effects.png-atlas
+[23:51:10] [Render thread/INFO]: Stopping!

--- a/test/tests/auto/Bedrock/BedrockContentTest.php
+++ b/test/tests/auto/Bedrock/BedrockContentTest.php
@@ -59,7 +59,7 @@ class BedrockContentTest extends PHPUnit\Framework\TestCase
                         )
 
                     [level:protected] => INFORM
-                    [time:protected] => 1652264719
+                    [time:protected] => 1653647119
                     [iterator:protected] => 0
                     [prefix:protected] => 10:25:19[Blocks][inform]
                 )
@@ -83,7 +83,7 @@ class BedrockContentTest extends PHPUnit\Framework\TestCase
                         )
 
                     [level:protected] => ERROR
-                    [time:protected] => 1652264719
+                    [time:protected] => 1653647119
                     [iterator:protected] => 0
                     [prefix:protected] => 10:25:19[Blocks][error]
                 )
@@ -131,7 +131,7 @@ class BedrockContentTest extends PHPUnit\Framework\TestCase
                         )
 
                     [level:protected] => INFORM
-                    [time:protected] => 1652264719
+                    [time:protected] => 1653647119
                     [iterator:protected] => 0
                     [prefix:protected] => 10:25:19[Blocks][inform]
                 )
@@ -155,7 +155,7 @@ class BedrockContentTest extends PHPUnit\Framework\TestCase
                         )
 
                     [level:protected] => ERROR
-                    [time:protected] => 1652264719
+                    [time:protected] => 1653647119
                     [iterator:protected] => 0
                     [prefix:protected] => 10:25:19[Blocks][error]
                 )
@@ -197,7 +197,7 @@ class BedrockContentTest extends PHPUnit\Framework\TestCase
                         )
 
                     [level:protected] => INFORM
-                    [time:protected] => 1652264719
+                    [time:protected] => 1653647119
                     [iterator:protected] => 0
                     [prefix:protected] => 10:25:19[Blocks][inform]
                 )
@@ -221,7 +221,7 @@ class BedrockContentTest extends PHPUnit\Framework\TestCase
                         )
 
                     [level:protected] => ERROR
-                    [time:protected] => 1652264719
+                    [time:protected] => 1653647119
                     [iterator:protected] => 0
                     [prefix:protected] => 10:25:19[Blocks][error]
                 )
@@ -245,7 +245,7 @@ class BedrockContentTest extends PHPUnit\Framework\TestCase
                         )
 
                     [level:protected] => ERROR
-                    [time:protected] => 1652264719
+                    [time:protected] => 1653647119
                     [iterator:protected] => 0
                     [prefix:protected] => 10:25:19[Item][error]
                 )
@@ -269,7 +269,7 @@ class BedrockContentTest extends PHPUnit\Framework\TestCase
                         )
 
                     [level:protected] => ERROR
-                    [time:protected] => 1652264719
+                    [time:protected] => 1653647119
                     [iterator:protected] => 0
                     [prefix:protected] => 10:25:19[Item][error]
                 )
@@ -299,7 +299,7 @@ class BedrockContentTest extends PHPUnit\Framework\TestCase
                         )
 
                     [level:protected] => ERROR
-                    [time:protected] => 1652264719
+                    [time:protected] => 1653647119
                     [iterator:protected] => 0
                     [prefix:protected] => 10:25:19[Json][error]
                 )
@@ -329,7 +329,7 @@ class BedrockContentTest extends PHPUnit\Framework\TestCase
                         )
 
                     [level:protected] => ERROR
-                    [time:protected] => 1652264720
+                    [time:protected] => 1653647120
                     [iterator:protected] => 0
                     [prefix:protected] => 10:25:20[Recipes][error]
                 )
@@ -359,7 +359,7 @@ class BedrockContentTest extends PHPUnit\Framework\TestCase
                         )
 
                     [level:protected] => ERROR
-                    [time:protected] => 1652264720
+                    [time:protected] => 1653647120
                     [iterator:protected] => 0
                     [prefix:protected] => 10:25:20[Recipes][error]
                 )
@@ -389,7 +389,7 @@ class BedrockContentTest extends PHPUnit\Framework\TestCase
                         )
 
                     [level:protected] => ERROR
-                    [time:protected] => 1652264720
+                    [time:protected] => 1653647120
                     [iterator:protected] => 0
                     [prefix:protected] => 10:25:20[Recipes][error]
                 )
@@ -413,7 +413,7 @@ class BedrockContentTest extends PHPUnit\Framework\TestCase
                         )
 
                     [level:protected] => WARNING
-                    [time:protected] => 1652264721
+                    [time:protected] => 1653647121
                     [iterator:protected] => 0
                     [prefix:protected] => 10:25:21[Commands][warning]
                 )
@@ -437,7 +437,7 @@ class BedrockContentTest extends PHPUnit\Framework\TestCase
                         )
 
                     [level:protected] => WARNING
-                    [time:protected] => 1652264721
+                    [time:protected] => 1653647121
                     [iterator:protected] => 0
                     [prefix:protected] => 10:25:21[Commands][warning]
                 )
@@ -461,7 +461,7 @@ class BedrockContentTest extends PHPUnit\Framework\TestCase
                         )
 
                     [level:protected] => WARNING
-                    [time:protected] => 1652264721
+                    [time:protected] => 1653647121
                     [iterator:protected] => 0
                     [prefix:protected] => 10:25:21[Commands][warning]
                 )
@@ -485,7 +485,7 @@ class BedrockContentTest extends PHPUnit\Framework\TestCase
                         )
 
                     [level:protected] => WARNING
-                    [time:protected] => 1652264721
+                    [time:protected] => 1653647121
                     [iterator:protected] => 0
                     [prefix:protected] => 10:25:21[Commands][warning]
                 )
@@ -509,7 +509,7 @@ class BedrockContentTest extends PHPUnit\Framework\TestCase
                         )
 
                     [level:protected] => WARNING
-                    [time:protected] => 1652264721
+                    [time:protected] => 1653647121
                     [iterator:protected] => 0
                     [prefix:protected] => 10:25:21[Commands][warning]
                 )
@@ -533,7 +533,7 @@ class BedrockContentTest extends PHPUnit\Framework\TestCase
                         )
 
                     [level:protected] => WARNING
-                    [time:protected] => 1652264721
+                    [time:protected] => 1653647121
                     [iterator:protected] => 0
                     [prefix:protected] => 10:25:21[Commands][warning]
                 )
@@ -557,7 +557,7 @@ class BedrockContentTest extends PHPUnit\Framework\TestCase
                         )
 
                     [level:protected] => WARNING
-                    [time:protected] => 1652264721
+                    [time:protected] => 1653647121
                     [iterator:protected] => 0
                     [prefix:protected] => 10:25:21[Commands][warning]
                 )
@@ -581,7 +581,7 @@ class BedrockContentTest extends PHPUnit\Framework\TestCase
                         )
 
                     [level:protected] => WARNING
-                    [time:protected] => 1652264721
+                    [time:protected] => 1653647121
                     [iterator:protected] => 0
                     [prefix:protected] => 10:25:21[Commands][warning]
                 )
@@ -605,7 +605,7 @@ class BedrockContentTest extends PHPUnit\Framework\TestCase
                         )
 
                     [level:protected] => WARNING
-                    [time:protected] => 1652264721
+                    [time:protected] => 1653647121
                     [iterator:protected] => 0
                     [prefix:protected] => 10:25:21[Commands][warning]
                 )

--- a/test/tests/auto/Bukkit/CraftbukkitPluginEventTest.php
+++ b/test/tests/auto/Bukkit/CraftbukkitPluginEventTest.php
@@ -2369,7 +2369,32 @@ Caused by: java.lang.NullPointerException
                     [value:protected] => 1.8
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginRuntimeProblem Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [03:41:13] [Server thread/INFO]: Starting minecraft server version 1.8
+                                            [number:protected] => 1
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [03:41:13] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 81
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginRuntimeProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -2581,9 +2606,11 @@ Caused by: java.lang.NullPointerException
 
         $this->assertEquals("Minecraft version: 1.8", $analysis[0]->getMessage());
 
-        $this->assertEquals("The plugin 'TrollBoss' has a problem while running.", $analysis[1]->getMessage());
-        $this->assertEquals("Install a different version of the plugin 'TrollBoss'.", $analysis[1][0]->getMessage());
-        $this->assertEquals("Remove the plugin 'TrollBoss'.", $analysis[1][1]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
+
+        $this->assertEquals("The plugin 'TrollBoss' has a problem while running.", $analysis[2]->getMessage());
+        $this->assertEquals("Install a different version of the plugin 'TrollBoss'.", $analysis[2][0]->getMessage());
+        $this->assertEquals("Remove the plugin 'TrollBoss'.", $analysis[2][1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Bukkit/CraftbukkitStart1132Test.php
+++ b/test/tests/auto/Bukkit/CraftbukkitStart1132Test.php
@@ -2088,9 +2088,34 @@ class CraftbukkitStart1132Test extends PHPUnit\Framework\TestCase
                     [value:protected] => 1.13.2
                 )
 
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [23:25:58] [Server thread/INFO]: Starting minecraft server version 1.13.2
+                                            [number:protected] => 2
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [23:25:58] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 105
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
         )
 
-    [iterator:protected] => 0
+    [iterator:protected] => 1
 )
 ';
         
@@ -2098,6 +2123,8 @@ class CraftbukkitStart1132Test extends PHPUnit\Framework\TestCase
         $this->assertEquals($expectedAnalysis, print_r($analysis, true));
 
         $this->assertEquals("Minecraft version: 1.13.2", $analysis[0]->getMessage());
+
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Bukkit/CraftbukkitWorldDuplicateTest.php
+++ b/test/tests/auto/Bukkit/CraftbukkitWorldDuplicateTest.php
@@ -2582,7 +2582,32 @@ class CraftbukkitWorldDuplicateTest extends PHPUnit\Framework\TestCase
                     [value:protected] => 1.13.2
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\WorldDuplicateProblem Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [18:14:46] [Server thread/INFO]: Starting minecraft server version 1.13.2
+                                            [number:protected] => 2
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [18:14:46] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 132
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\WorldDuplicateProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -2634,9 +2659,11 @@ class CraftbukkitWorldDuplicateTest extends PHPUnit\Framework\TestCase
 
         $this->assertEquals("Minecraft version: 1.13.2", $analysis[0]->getMessage());
 
-        $this->assertEquals("World 'hell' is a duplicate of another world and has been prevented from loading.", $analysis[1]->getMessage());
-        $this->assertEquals("Delete the file 'hell/uid.dat'.", $analysis[1][0]->getMessage());
-        $this->assertEquals("Delete the file 'hell'.", $analysis[1][1]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
+
+        $this->assertEquals("World 'hell' is a duplicate of another world and has been prevented from loading.", $analysis[2]->getMessage());
+        $this->assertEquals("Delete the file 'hell/uid.dat'.", $analysis[2][0]->getMessage());
+        $this->assertEquals("Delete the file 'hell'.", $analysis[2][1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Bukkit/PaperAmbiguousPluginNameTest.php
+++ b/test/tests/auto/Bukkit/PaperAmbiguousPluginNameTest.php
@@ -302,7 +302,32 @@ class PaperAmbiguousPluginNameTest extends PHPUnit\Framework\TestCase
                     [value:protected] => 1.13.2
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\AmbiguousPluginNameProblem Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [19:23:08] [Server thread/INFO]: Starting minecraft server version 1.13.2
+                                            [number:protected] => 2
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [19:23:08] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 12
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\AmbiguousPluginNameProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -345,7 +370,7 @@ class PaperAmbiguousPluginNameTest extends PHPUnit\Framework\TestCase
                     [pluginName:protected] => Multiverse-Core
                 )
 
-            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\AmbiguousPluginNameProblem Object
+            [3] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\AmbiguousPluginNameProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -390,7 +415,7 @@ class PaperAmbiguousPluginNameTest extends PHPUnit\Framework\TestCase
 
         )
 
-    [iterator:protected] => 2
+    [iterator:protected] => 3
 )
 ';
         
@@ -399,13 +424,15 @@ class PaperAmbiguousPluginNameTest extends PHPUnit\Framework\TestCase
 
         $this->assertEquals("Minecraft version: 1.13.2", $analysis[0]->getMessage());
 
-        $this->assertEquals("There are multiple plugin files for the plugin name 'Multiverse-Core': 'Multiverse-Core-3.0.0-SNAPSHOT.jar' and 'Multiverse-Core-2.5.jar'.", $analysis[1]->getMessage());
-        $this->assertEquals("Delete the file 'plugins/Multiverse-Core-3.0.0-SNAPSHOT.jar'.", $analysis[1][0]->getMessage());
-        $this->assertEquals("Delete the file 'plugins/Multiverse-Core-2.5.jar'.", $analysis[1][1]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
 
-        $this->assertEquals("There are multiple plugin files for the plugin name 'WorldEdit': 'worldedit-bukkit-7.0.0-beta-05.jar' and 'worldedit-bukkit-7.0.0-beta-01.jar'.", $analysis[2]->getMessage());
-        $this->assertEquals("Delete the file 'plugins/worldedit-bukkit-7.0.0-beta-05.jar'.", $analysis[2][0]->getMessage());
-        $this->assertEquals("Delete the file 'plugins/worldedit-bukkit-7.0.0-beta-01.jar'.", $analysis[2][1]->getMessage());
+        $this->assertEquals("There are multiple plugin files for the plugin name 'Multiverse-Core': 'Multiverse-Core-3.0.0-SNAPSHOT.jar' and 'Multiverse-Core-2.5.jar'.", $analysis[2]->getMessage());
+        $this->assertEquals("Delete the file 'plugins/Multiverse-Core-3.0.0-SNAPSHOT.jar'.", $analysis[2][0]->getMessage());
+        $this->assertEquals("Delete the file 'plugins/Multiverse-Core-2.5.jar'.", $analysis[2][1]->getMessage());
+
+        $this->assertEquals("There are multiple plugin files for the plugin name 'WorldEdit': 'worldedit-bukkit-7.0.0-beta-05.jar' and 'worldedit-bukkit-7.0.0-beta-01.jar'.", $analysis[3]->getMessage());
+        $this->assertEquals("Delete the file 'plugins/worldedit-bukkit-7.0.0-beta-05.jar'.", $analysis[3][0]->getMessage());
+        $this->assertEquals("Delete the file 'plugins/worldedit-bukkit-7.0.0-beta-01.jar'.", $analysis[3][1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Bukkit/PaperPluginDependency1161Test.php
+++ b/test/tests/auto/Bukkit/PaperPluginDependency1161Test.php
@@ -712,7 +712,32 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_242]
                     [value:protected] => 1.16.1
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginDependencyProblem Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [09:59:22] [Server thread/INFO]: Starting minecraft server version 1.16.1
+                                            [number:protected] => 4
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [09:59:22] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 29
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -807,9 +832,11 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_242]
 
         $this->assertEquals("Minecraft version: 1.16.1", $analysis[0]->getMessage());
 
-        $this->assertEquals("The plugin 'LuckPermsChat-2.0.2' is missing the required the plugin 'LuckPerms'.", $analysis[1]->getMessage());
-        $this->assertEquals("Install the plugin 'LuckPerms'.", $analysis[1][0]->getMessage());
-        $this->assertEquals("Delete the file 'plugins/LuckPermsChat-2.0.2.jar'.", $analysis[1][1]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
+
+        $this->assertEquals("The plugin 'LuckPermsChat-2.0.2' is missing the required the plugin 'LuckPerms'.", $analysis[2]->getMessage());
+        $this->assertEquals("Install the plugin 'LuckPerms'.", $analysis[2][0]->getMessage());
+        $this->assertEquals("Delete the file 'plugins/LuckPermsChat-2.0.2.jar'.", $analysis[2][1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Bukkit/PaperPluginDisablingTest.php
+++ b/test/tests/auto/Bukkit/PaperPluginDisablingTest.php
@@ -2925,7 +2925,32 @@ org.bukkit.plugin.IllegalPluginAccessException: Plugin attempted to register mau
                     [value:protected] => 1.13.2
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginEnablingProblem Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [12:04:31] [Server thread/INFO]: Starting minecraft server version 1.13.2
+                                            [number:protected] => 2
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [12:04:31] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 138
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginEnablingProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -3042,7 +3067,7 @@ org.bukkit.plugin.IllegalPluginAccessException: Plugin attempted to register mau
                     [pluginName:protected] => SuperLobbyPlus
                 )
 
-            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginDisablingProblem Object
+            [3] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginDisablingProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -3185,7 +3210,7 @@ org.bukkit.plugin.IllegalPluginAccessException: Plugin attempted to register mau
 
         )
 
-    [iterator:protected] => 2
+    [iterator:protected] => 1
 )
 ';
         
@@ -3194,13 +3219,15 @@ org.bukkit.plugin.IllegalPluginAccessException: Plugin attempted to register mau
 
         $this->assertEquals("Minecraft version: 1.13.2", $analysis[0]->getMessage());
 
-        $this->assertEquals("The plugin 'SuperLobbyPlus' could not be enabled.", $analysis[1]->getMessage());
-        $this->assertEquals("Install a different version of the plugin 'SuperLobbyPlus'.", $analysis[1][0]->getMessage());
-        $this->assertEquals("Remove the plugin 'SuperLobbyPlus'.", $analysis[1][1]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
 
-        $this->assertEquals("The plugin 'SuperLobbyPlus' could not be disabled.", $analysis[2]->getMessage());
+        $this->assertEquals("The plugin 'SuperLobbyPlus' could not be enabled.", $analysis[2]->getMessage());
         $this->assertEquals("Install a different version of the plugin 'SuperLobbyPlus'.", $analysis[2][0]->getMessage());
         $this->assertEquals("Remove the plugin 'SuperLobbyPlus'.", $analysis[2][1]->getMessage());
+
+        $this->assertEquals("The plugin 'SuperLobbyPlus' could not be disabled.", $analysis[3]->getMessage());
+        $this->assertEquals("Install a different version of the plugin 'SuperLobbyPlus'.", $analysis[3][0]->getMessage());
+        $this->assertEquals("Remove the plugin 'SuperLobbyPlus'.", $analysis[3][1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Bukkit/PaperStart1132Test.php
+++ b/test/tests/auto/Bukkit/PaperStart1132Test.php
@@ -2202,9 +2202,34 @@ class PaperStart1132Test extends PHPUnit\Framework\TestCase
                     [value:protected] => 1.13.2
                 )
 
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [00:09:02] [Server thread/INFO]: Starting minecraft server version 1.13.2
+                                            [number:protected] => 2
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [00:09:02] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 111
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
         )
 
-    [iterator:protected] => 0
+    [iterator:protected] => 1
 )
 ';
         
@@ -2212,6 +2237,8 @@ class PaperStart1132Test extends PHPUnit\Framework\TestCase
         $this->assertEquals($expectedAnalysis, print_r($analysis, true));
 
         $this->assertEquals("Minecraft version: 1.13.2", $analysis[0]->getMessage());
+
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Bukkit/PaperStart188Test.php
+++ b/test/tests/auto/Bukkit/PaperStart188Test.php
@@ -3855,9 +3855,34 @@ class PaperStart188Test extends PHPUnit\Framework\TestCase
                     [value:protected] => 1.8.8
                 )
 
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [18:34:53] [Server thread/INFO]: Starting minecraft server version 1.8.8
+                                            [number:protected] => 1
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [18:34:53] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 199
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
         )
 
-    [iterator:protected] => 0
+    [iterator:protected] => 1
 )
 ';
         
@@ -3865,6 +3890,8 @@ class PaperStart188Test extends PHPUnit\Framework\TestCase
         $this->assertEquals($expectedAnalysis, print_r($analysis, true));
 
         $this->assertEquals("Minecraft version: 1.8.8", $analysis[0]->getMessage());
+
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Bukkit/PaperVersionDowngradeTest.php
+++ b/test/tests/auto/Bukkit/PaperVersionDowngradeTest.php
@@ -3006,7 +3006,32 @@ Caused by: java.lang.ThreadDeath
                     [value:protected] => 1.16.4
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Paper\VersionDowngradeProblem Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [13:51:11] [Server thread/INFO]: Starting minecraft server version 1.16.4
+                                            [number:protected] => 5
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [13:51:11] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 56
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Paper\VersionDowngradeProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -3053,9 +3078,11 @@ Caused by: java.lang.ThreadDeath
 
         $this->assertEquals("Minecraft version: 1.16.4", $analysis[0]->getMessage());
 
-        $this->assertEquals("Your world was used on a newer version before.", $analysis[1]->getMessage());
-        $this->assertEquals("Install a newer version of Minecraft.", $analysis[1][0]->getMessage());
-        $this->assertEquals("Generate a new world.", $analysis[1][1]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
+
+        $this->assertEquals("Your world was used on a newer version before.", $analysis[2]->getMessage());
+        $this->assertEquals("Install a newer version of Minecraft.", $analysis[2][0]->getMessage());
+        $this->assertEquals("Generate a new world.", $analysis[2][1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Bukkit/Plugin/SpigotAuthmeShutdownTest.php
+++ b/test/tests/auto/Bukkit/Plugin/SpigotAuthmeShutdownTest.php
@@ -10509,7 +10509,32 @@ org.bukkit.plugin.UnknownDependencyException: Languagy
                     [value:protected] => 1.12
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginDependencyProblem Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [16:00:32] [Server thread/INFO]: Starting minecraft server version 1.12
+                                            [number:protected] => 1
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [16:00:32] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 547
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -10587,7 +10612,7 @@ org.bukkit.plugin.UnknownDependencyException: Languagy
                     [dependencyPluginName:protected] => Languagy
                 )
 
-            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\Plugin\AuthMeShutdownProblem Object
+            [3] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\Plugin\AuthMeShutdownProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -10641,7 +10666,7 @@ org.bukkit.plugin.UnknownDependencyException: Languagy
 
         )
 
-    [iterator:protected] => 2
+    [iterator:protected] => 1
 )
 ';
         
@@ -10650,15 +10675,17 @@ org.bukkit.plugin.UnknownDependencyException: Languagy
 
         $this->assertEquals("Minecraft version: 1.12", $analysis[0]->getMessage());
 
-        $this->assertEquals("The plugin 'AnvilLogin' is missing the required the plugin 'Languagy'.", $analysis[1]->getMessage());
-        $this->assertEquals("Install the plugin 'Languagy'.", $analysis[1][0]->getMessage());
-        $this->assertEquals("Delete the file 'plugins/AnvilLogin.jar'.", $analysis[1][1]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
 
-        $this->assertEquals("The plugin 'AuthMe' fails to load and shuts the server down.", $analysis[2]->getMessage());
-        $this->assertEquals("Edit the file 'plugins/AuthMe/config.yml'. Set 'stopServer' to 'true'.", $analysis[2][0]->getMessage());
-        $this->assertEquals("Configure the plugin AuthMe (plugins/AuthMe/config.yml).", $analysis[2][1]->getMessage());
-        $this->assertEquals("Install a different version of the plugin 'AuthMe'.", $analysis[2][2]->getMessage());
-        $this->assertEquals("Remove the plugin 'AuthMe'.", $analysis[2][3]->getMessage());
+        $this->assertEquals("The plugin 'AnvilLogin' is missing the required the plugin 'Languagy'.", $analysis[2]->getMessage());
+        $this->assertEquals("Install the plugin 'Languagy'.", $analysis[2][0]->getMessage());
+        $this->assertEquals("Delete the file 'plugins/AnvilLogin.jar'.", $analysis[2][1]->getMessage());
+
+        $this->assertEquals("The plugin 'AuthMe' fails to load and shuts the server down.", $analysis[3]->getMessage());
+        $this->assertEquals("Edit the file 'plugins/AuthMe/config.yml'. Set 'stopServer' to 'true'.", $analysis[3][0]->getMessage());
+        $this->assertEquals("Configure the plugin AuthMe (plugins/AuthMe/config.yml).", $analysis[3][1]->getMessage());
+        $this->assertEquals("Install a different version of the plugin 'AuthMe'.", $analysis[3][2]->getMessage());
+        $this->assertEquals("Remove the plugin 'AuthMe'.", $analysis[3][3]->getMessage());
 
     }
 }

--- a/test/tests/auto/Bukkit/Plugin/SpigotMultiverseLoadTest.php
+++ b/test/tests/auto/Bukkit/Plugin/SpigotMultiverseLoadTest.php
@@ -5135,7 +5135,32 @@ class SpigotMultiverseLoadTest extends PHPUnit\Framework\TestCase
                     [value:protected] => 1.13.2
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\Plugin\MultiverseLoadProblem Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [14:33:06] [Server thread/INFO]: Starting minecraft server version 1.13.2
+                                            [number:protected] => 2
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [14:33:06] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 266
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\Plugin\MultiverseLoadProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -5186,9 +5211,11 @@ class SpigotMultiverseLoadTest extends PHPUnit\Framework\TestCase
 
         $this->assertEquals("Minecraft version: 1.13.2", $analysis[0]->getMessage());
 
-        $this->assertEquals("The world 'New_world' could not be loaded because it contains errors and is probably corrupt.", $analysis[1]->getMessage());
-        $this->assertEquals("Repair the world 'New_world', e.g. by using Minecraft Region Fixer or MCEdit.", $analysis[1][0]->getMessage());
-        $this->assertEquals("Delete the file 'New_world'.", $analysis[1][1]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
+
+        $this->assertEquals("The world 'New_world' could not be loaded because it contains errors and is probably corrupt.", $analysis[2]->getMessage());
+        $this->assertEquals("Repair the world 'New_world', e.g. by using Minecraft Region Fixer or MCEdit.", $analysis[2][0]->getMessage());
+        $this->assertEquals("Delete the file 'New_world'.", $analysis[2][1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Bukkit/Plugin/SpigotPermissionsexConfigTest.php
+++ b/test/tests/auto/Bukkit/Plugin/SpigotPermissionsexConfigTest.php
@@ -24496,7 +24496,32 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
                     [value:protected] => 1.8
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginLoadProblem Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [21:08:50] [Server thread/INFO]: Starting minecraft server version 1.8
+                                            [number:protected] => 1
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [21:08:50] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 1137
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginLoadProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -24627,7 +24652,7 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
                     [pluginPath:protected] => plugins/Troll_v3.8.jar
                 )
 
-            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginLoadProblem Object
+            [3] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginLoadProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -24758,7 +24783,7 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
                     [pluginPath:protected] => plugins/AdminSystem ???.jar
                 )
 
-            [3] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginLoadProblem Object
+            [4] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginLoadProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -24853,7 +24878,7 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
                     [pluginPath:protected] => plugins/ChatTroll_v2.1.jar
                 )
 
-            [4] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\AmbiguousPluginNameProblem Object
+            [5] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\AmbiguousPluginNameProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -24896,7 +24921,7 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
                     [pluginName:protected] => SkyPvP
                 )
 
-            [5] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginLoadProblem Object
+            [6] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginLoadProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -25027,7 +25052,7 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
                     [pluginPath:protected] => plugins/CommunityBETA.jar
                 )
 
-            [6] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\AmbiguousPluginNameProblem Object
+            [7] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\AmbiguousPluginNameProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -25070,7 +25095,7 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
                     [pluginName:protected] => BetterNick
                 )
 
-            [7] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginLoadProblem Object
+            [8] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginLoadProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -25165,7 +25190,7 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
                     [pluginPath:protected] => plugins/bstats-bukkit-1.2.jar
                 )
 
-            [8] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginLoadProblem Object
+            [9] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginLoadProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -25512,7 +25537,7 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
                     [pluginPath:protected] => plugins/SlashServer.jar
                 )
 
-            [9] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginDependencyProblem Object
+            [10] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -25590,7 +25615,7 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
                     [dependencyPluginName:protected] => WorldGuard
                 )
 
-            [10] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginLoadProblem Object
+            [11] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginLoadProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -25793,7 +25818,7 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
                     [pluginPath:protected] => plugins/PortalStones1.5.jar
                 )
 
-            [11] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginEnablingProblem Object
+            [12] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginEnablingProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -25910,7 +25935,7 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
                     [pluginName:protected] => SuperLobbyPlus
                 )
 
-            [12] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginEnablingProblem Object
+            [13] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginEnablingProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -26081,7 +26106,7 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
                     [pluginName:protected] => GlobalMarket
                 )
 
-            [13] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\Plugin\PermissionsExConfigProblem Object
+            [14] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\Plugin\PermissionsExConfigProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -26642,7 +26667,7 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
                     [iterator:protected] => 0
                 )
 
-            [14] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginEnablingProblem Object
+            [15] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginEnablingProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -26765,7 +26790,7 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
                     [pluginName:protected] => TalkingBot
                 )
 
-            [15] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginDisablingProblem Object
+            [16] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginDisablingProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -26918,7 +26943,7 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
                     [pluginName:protected] => CustomRanks
                 )
 
-            [16] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginEnablingProblem Object
+            [17] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginEnablingProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -27035,7 +27060,7 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
                     [pluginName:protected] => CustomRanks
                 )
 
-            [17] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginDisablingProblem Object
+            [18] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginDisablingProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -27176,7 +27201,7 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
                     [pluginName:protected] => CitizensCMD
                 )
 
-            [18] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginEnablingProblem Object
+            [19] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginEnablingProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -27359,7 +27384,7 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
                     [pluginName:protected] => RedProtect
                 )
 
-            [19] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginDisablingProblem Object
+            [20] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginDisablingProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -27536,7 +27561,7 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
                     [pluginName:protected] => RedProtect
                 )
 
-            [20] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginDisablingProblem Object
+            [21] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginDisablingProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -27649,7 +27674,7 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
 
         )
 
-    [iterator:protected] => 20
+    [iterator:protected] => 1
 )
 ';
         
@@ -27658,85 +27683,87 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
 
         $this->assertEquals("Minecraft version: 1.8", $analysis[0]->getMessage());
 
-        $this->assertEquals("The plugin 'Troll_v3.8' could not be loaded.", $analysis[1]->getMessage());
-        $this->assertEquals("Install a different version of the plugin 'Troll_v3.8'.", $analysis[1][0]->getMessage());
-        $this->assertEquals("Delete the file 'plugins/Troll_v3.8.jar'.", $analysis[1][1]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
 
-        $this->assertEquals("The plugin 'AdminSystem ???' could not be loaded.", $analysis[2]->getMessage());
-        $this->assertEquals("Install a different version of the plugin 'AdminSystem ???'.", $analysis[2][0]->getMessage());
-        $this->assertEquals("Delete the file 'plugins/AdminSystem ???.jar'.", $analysis[2][1]->getMessage());
+        $this->assertEquals("The plugin 'Troll_v3.8' could not be loaded.", $analysis[2]->getMessage());
+        $this->assertEquals("Install a different version of the plugin 'Troll_v3.8'.", $analysis[2][0]->getMessage());
+        $this->assertEquals("Delete the file 'plugins/Troll_v3.8.jar'.", $analysis[2][1]->getMessage());
 
-        $this->assertEquals("The plugin 'ChatTroll_v2.1' could not be loaded.", $analysis[3]->getMessage());
-        $this->assertEquals("Install a different version of the plugin 'ChatTroll_v2.1'.", $analysis[3][0]->getMessage());
-        $this->assertEquals("Delete the file 'plugins/ChatTroll_v2.1.jar'.", $analysis[3][1]->getMessage());
+        $this->assertEquals("The plugin 'AdminSystem ???' could not be loaded.", $analysis[3]->getMessage());
+        $this->assertEquals("Install a different version of the plugin 'AdminSystem ???'.", $analysis[3][0]->getMessage());
+        $this->assertEquals("Delete the file 'plugins/AdminSystem ???.jar'.", $analysis[3][1]->getMessage());
 
-        $this->assertEquals("There are multiple plugin files for the plugin name 'SkyPvP': 'SkyPvPFree.jar' and 'SkyPvP.jar'.", $analysis[4]->getMessage());
-        $this->assertEquals("Delete the file 'plugins/SkyPvPFree.jar'.", $analysis[4][0]->getMessage());
-        $this->assertEquals("Delete the file 'plugins/SkyPvP.jar'.", $analysis[4][1]->getMessage());
+        $this->assertEquals("The plugin 'ChatTroll_v2.1' could not be loaded.", $analysis[4]->getMessage());
+        $this->assertEquals("Install a different version of the plugin 'ChatTroll_v2.1'.", $analysis[4][0]->getMessage());
+        $this->assertEquals("Delete the file 'plugins/ChatTroll_v2.1.jar'.", $analysis[4][1]->getMessage());
 
-        $this->assertEquals("The plugin 'CommunityBETA' could not be loaded.", $analysis[5]->getMessage());
-        $this->assertEquals("Install a different version of the plugin 'CommunityBETA'.", $analysis[5][0]->getMessage());
-        $this->assertEquals("Delete the file 'plugins/CommunityBETA.jar'.", $analysis[5][1]->getMessage());
+        $this->assertEquals("There are multiple plugin files for the plugin name 'SkyPvP': 'SkyPvPFree.jar' and 'SkyPvP.jar'.", $analysis[5]->getMessage());
+        $this->assertEquals("Delete the file 'plugins/SkyPvPFree.jar'.", $analysis[5][0]->getMessage());
+        $this->assertEquals("Delete the file 'plugins/SkyPvP.jar'.", $analysis[5][1]->getMessage());
 
-        $this->assertEquals("There are multiple plugin files for the plugin name 'BetterNick': 'BetterNick 1.13.X.jar' and 'BetterNick 1.8.3 - 1.12.2.jar'.", $analysis[6]->getMessage());
-        $this->assertEquals("Delete the file 'plugins/BetterNick 1.13.X.jar'.", $analysis[6][0]->getMessage());
-        $this->assertEquals("Delete the file 'plugins/BetterNick 1.8.3 - 1.12.2.jar'.", $analysis[6][1]->getMessage());
+        $this->assertEquals("The plugin 'CommunityBETA' could not be loaded.", $analysis[6]->getMessage());
+        $this->assertEquals("Install a different version of the plugin 'CommunityBETA'.", $analysis[6][0]->getMessage());
+        $this->assertEquals("Delete the file 'plugins/CommunityBETA.jar'.", $analysis[6][1]->getMessage());
 
-        $this->assertEquals("The plugin 'bstats-bukkit-1.2' could not be loaded.", $analysis[7]->getMessage());
-        $this->assertEquals("Install a different version of the plugin 'bstats-bukkit-1.2'.", $analysis[7][0]->getMessage());
-        $this->assertEquals("Delete the file 'plugins/bstats-bukkit-1.2.jar'.", $analysis[7][1]->getMessage());
+        $this->assertEquals("There are multiple plugin files for the plugin name 'BetterNick': 'BetterNick 1.13.X.jar' and 'BetterNick 1.8.3 - 1.12.2.jar'.", $analysis[7]->getMessage());
+        $this->assertEquals("Delete the file 'plugins/BetterNick 1.13.X.jar'.", $analysis[7][0]->getMessage());
+        $this->assertEquals("Delete the file 'plugins/BetterNick 1.8.3 - 1.12.2.jar'.", $analysis[7][1]->getMessage());
 
-        $this->assertEquals("The plugin 'SlashServer' could not be loaded.", $analysis[8]->getMessage());
-        $this->assertEquals("Install a different version of the plugin 'SlashServer'.", $analysis[8][0]->getMessage());
-        $this->assertEquals("Delete the file 'plugins/SlashServer.jar'.", $analysis[8][1]->getMessage());
+        $this->assertEquals("The plugin 'bstats-bukkit-1.2' could not be loaded.", $analysis[8]->getMessage());
+        $this->assertEquals("Install a different version of the plugin 'bstats-bukkit-1.2'.", $analysis[8][0]->getMessage());
+        $this->assertEquals("Delete the file 'plugins/bstats-bukkit-1.2.jar'.", $analysis[8][1]->getMessage());
 
-        $this->assertEquals("The plugin 'AreaShop' is missing the required the plugin 'WorldGuard'.", $analysis[9]->getMessage());
-        $this->assertEquals("Install the plugin 'WorldGuard'.", $analysis[9][0]->getMessage());
-        $this->assertEquals("Delete the file 'plugins/AreaShop.jar'.", $analysis[9][1]->getMessage());
+        $this->assertEquals("The plugin 'SlashServer' could not be loaded.", $analysis[9]->getMessage());
+        $this->assertEquals("Install a different version of the plugin 'SlashServer'.", $analysis[9][0]->getMessage());
+        $this->assertEquals("Delete the file 'plugins/SlashServer.jar'.", $analysis[9][1]->getMessage());
 
-        $this->assertEquals("The plugin 'PortalStones1.5' could not be loaded.", $analysis[10]->getMessage());
-        $this->assertEquals("Install a different version of the plugin 'PortalStones1.5'.", $analysis[10][0]->getMessage());
-        $this->assertEquals("Delete the file 'plugins/PortalStones1.5.jar'.", $analysis[10][1]->getMessage());
+        $this->assertEquals("The plugin 'AreaShop' is missing the required the plugin 'WorldGuard'.", $analysis[10]->getMessage());
+        $this->assertEquals("Install the plugin 'WorldGuard'.", $analysis[10][0]->getMessage());
+        $this->assertEquals("Delete the file 'plugins/AreaShop.jar'.", $analysis[10][1]->getMessage());
 
-        $this->assertEquals("The plugin 'SuperLobbyPlus' could not be enabled.", $analysis[11]->getMessage());
-        $this->assertEquals("Install a different version of the plugin 'SuperLobbyPlus'.", $analysis[11][0]->getMessage());
-        $this->assertEquals("Remove the plugin 'SuperLobbyPlus'.", $analysis[11][1]->getMessage());
+        $this->assertEquals("The plugin 'PortalStones1.5' could not be loaded.", $analysis[11]->getMessage());
+        $this->assertEquals("Install a different version of the plugin 'PortalStones1.5'.", $analysis[11][0]->getMessage());
+        $this->assertEquals("Delete the file 'plugins/PortalStones1.5.jar'.", $analysis[11][1]->getMessage());
 
-        $this->assertEquals("The plugin 'GlobalMarket' could not be enabled.", $analysis[12]->getMessage());
-        $this->assertEquals("Install a different version of the plugin 'GlobalMarket'.", $analysis[12][0]->getMessage());
-        $this->assertEquals("Remove the plugin 'GlobalMarket'.", $analysis[12][1]->getMessage());
+        $this->assertEquals("The plugin 'SuperLobbyPlus' could not be enabled.", $analysis[12]->getMessage());
+        $this->assertEquals("Install a different version of the plugin 'SuperLobbyPlus'.", $analysis[12][0]->getMessage());
+        $this->assertEquals("Remove the plugin 'SuperLobbyPlus'.", $analysis[12][1]->getMessage());
 
-        $this->assertEquals("The configuration of the plugin 'PermissionsEx' is invalid.", $analysis[13]->getMessage());
-        $this->assertEquals("Configure the plugin PermissionsEx (plugins/PermissionsEx/permissions.yml).", $analysis[13][0]->getMessage());
-        $this->assertEquals("Remove the plugin 'PermissionsEx'.", $analysis[13][1]->getMessage());
+        $this->assertEquals("The plugin 'GlobalMarket' could not be enabled.", $analysis[13]->getMessage());
+        $this->assertEquals("Install a different version of the plugin 'GlobalMarket'.", $analysis[13][0]->getMessage());
+        $this->assertEquals("Remove the plugin 'GlobalMarket'.", $analysis[13][1]->getMessage());
 
-        $this->assertEquals("The plugin 'TalkingBot' could not be enabled.", $analysis[14]->getMessage());
-        $this->assertEquals("Install a different version of the plugin 'TalkingBot'.", $analysis[14][0]->getMessage());
-        $this->assertEquals("Remove the plugin 'TalkingBot'.", $analysis[14][1]->getMessage());
+        $this->assertEquals("The configuration of the plugin 'PermissionsEx' is invalid.", $analysis[14]->getMessage());
+        $this->assertEquals("Configure the plugin PermissionsEx (plugins/PermissionsEx/permissions.yml).", $analysis[14][0]->getMessage());
+        $this->assertEquals("Remove the plugin 'PermissionsEx'.", $analysis[14][1]->getMessage());
 
-        $this->assertEquals("The plugin 'CustomRanks' could not be disabled.", $analysis[15]->getMessage());
-        $this->assertEquals("Install a different version of the plugin 'CustomRanks'.", $analysis[15][0]->getMessage());
-        $this->assertEquals("Remove the plugin 'CustomRanks'.", $analysis[15][1]->getMessage());
+        $this->assertEquals("The plugin 'TalkingBot' could not be enabled.", $analysis[15]->getMessage());
+        $this->assertEquals("Install a different version of the plugin 'TalkingBot'.", $analysis[15][0]->getMessage());
+        $this->assertEquals("Remove the plugin 'TalkingBot'.", $analysis[15][1]->getMessage());
 
-        $this->assertEquals("The plugin 'CustomRanks' could not be enabled.", $analysis[16]->getMessage());
+        $this->assertEquals("The plugin 'CustomRanks' could not be disabled.", $analysis[16]->getMessage());
         $this->assertEquals("Install a different version of the plugin 'CustomRanks'.", $analysis[16][0]->getMessage());
         $this->assertEquals("Remove the plugin 'CustomRanks'.", $analysis[16][1]->getMessage());
 
-        $this->assertEquals("The plugin 'CitizensCMD' could not be disabled.", $analysis[17]->getMessage());
-        $this->assertEquals("Install a different version of the plugin 'CitizensCMD'.", $analysis[17][0]->getMessage());
-        $this->assertEquals("Remove the plugin 'CitizensCMD'.", $analysis[17][1]->getMessage());
+        $this->assertEquals("The plugin 'CustomRanks' could not be enabled.", $analysis[17]->getMessage());
+        $this->assertEquals("Install a different version of the plugin 'CustomRanks'.", $analysis[17][0]->getMessage());
+        $this->assertEquals("Remove the plugin 'CustomRanks'.", $analysis[17][1]->getMessage());
 
-        $this->assertEquals("The plugin 'RedProtect' could not be enabled.", $analysis[18]->getMessage());
-        $this->assertEquals("Install a different version of the plugin 'RedProtect'.", $analysis[18][0]->getMessage());
-        $this->assertEquals("Remove the plugin 'RedProtect'.", $analysis[18][1]->getMessage());
+        $this->assertEquals("The plugin 'CitizensCMD' could not be disabled.", $analysis[18]->getMessage());
+        $this->assertEquals("Install a different version of the plugin 'CitizensCMD'.", $analysis[18][0]->getMessage());
+        $this->assertEquals("Remove the plugin 'CitizensCMD'.", $analysis[18][1]->getMessage());
 
-        $this->assertEquals("The plugin 'RedProtect' could not be disabled.", $analysis[19]->getMessage());
+        $this->assertEquals("The plugin 'RedProtect' could not be enabled.", $analysis[19]->getMessage());
         $this->assertEquals("Install a different version of the plugin 'RedProtect'.", $analysis[19][0]->getMessage());
         $this->assertEquals("Remove the plugin 'RedProtect'.", $analysis[19][1]->getMessage());
 
-        $this->assertEquals("The plugin 'SuperLobbyPlus' could not be disabled.", $analysis[20]->getMessage());
-        $this->assertEquals("Install a different version of the plugin 'SuperLobbyPlus'.", $analysis[20][0]->getMessage());
-        $this->assertEquals("Remove the plugin 'SuperLobbyPlus'.", $analysis[20][1]->getMessage());
+        $this->assertEquals("The plugin 'RedProtect' could not be disabled.", $analysis[20]->getMessage());
+        $this->assertEquals("Install a different version of the plugin 'RedProtect'.", $analysis[20][0]->getMessage());
+        $this->assertEquals("Remove the plugin 'RedProtect'.", $analysis[20][1]->getMessage());
+
+        $this->assertEquals("The plugin 'SuperLobbyPlus' could not be disabled.", $analysis[21]->getMessage());
+        $this->assertEquals("Install a different version of the plugin 'SuperLobbyPlus'.", $analysis[21][0]->getMessage());
+        $this->assertEquals("Remove the plugin 'SuperLobbyPlus'.", $analysis[21][1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Bukkit/SpigotChunkEntityExceptionTest.php
+++ b/test/tests/auto/Bukkit/SpigotChunkEntityExceptionTest.php
@@ -825,7 +825,32 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
                     [value:protected] => 1.8.8
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\ChunkLoadExceptionProblem Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [23:49:54] [Server thread/INFO]: Starting minecraft server version 1.8.8
+                                            [number:protected] => 1
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [23:49:54] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 35
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\ChunkLoadExceptionProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -969,10 +994,12 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
 
         $this->assertEquals("Minecraft version: 1.8.8", $analysis[0]->getMessage());
 
-        $this->assertEquals("There was an exception while loading the world chunks.", $analysis[1]->getMessage());
-        $this->assertEquals("Repair the world 'world', e.g. by using Minecraft Region Fixer or MCEdit.", $analysis[1][0]->getMessage());
-        $this->assertEquals("Delete the file 'world'.", $analysis[1][1]->getMessage());
-        $this->assertEquals("Remove the problematic chunk from the world, e.g. with MCEdit or by removing the region file.", $analysis[1][2]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
+
+        $this->assertEquals("There was an exception while loading the world chunks.", $analysis[2]->getMessage());
+        $this->assertEquals("Repair the world 'world', e.g. by using Minecraft Region Fixer or MCEdit.", $analysis[2][0]->getMessage());
+        $this->assertEquals("Delete the file 'world'.", $analysis[2][1]->getMessage());
+        $this->assertEquals("Remove the problematic chunk from the world, e.g. with MCEdit or by removing the region file.", $analysis[2][2]->getMessage());
 
     }
 }

--- a/test/tests/auto/Bukkit/SpigotChunkLoadExceptionTest.php
+++ b/test/tests/auto/Bukkit/SpigotChunkLoadExceptionTest.php
@@ -3237,7 +3237,32 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
                     [value:protected] => 1.8.8
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\ChunkLoadExceptionProblem Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [15:29:52] [Server thread/INFO]: Starting minecraft server version 1.8.8
+                                            [number:protected] => 1
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [15:29:52] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 159
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\ChunkLoadExceptionProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -3429,10 +3454,12 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
 
         $this->assertEquals("Minecraft version: 1.8.8", $analysis[0]->getMessage());
 
-        $this->assertEquals("There was an exception while loading the world chunks.", $analysis[1]->getMessage());
-        $this->assertEquals("Repair the world 'world', e.g. by using Minecraft Region Fixer or MCEdit.", $analysis[1][0]->getMessage());
-        $this->assertEquals("Delete the file 'world'.", $analysis[1][1]->getMessage());
-        $this->assertEquals("Remove the problematic chunk from the world, e.g. with MCEdit or by removing the region file.", $analysis[1][2]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
+
+        $this->assertEquals("There was an exception while loading the world chunks.", $analysis[2]->getMessage());
+        $this->assertEquals("Repair the world 'world', e.g. by using Minecraft Region Fixer or MCEdit.", $analysis[2][0]->getMessage());
+        $this->assertEquals("Delete the file 'world'.", $analysis[2][1]->getMessage());
+        $this->assertEquals("Remove the problematic chunk from the world, e.g. with MCEdit or by removing the region file.", $analysis[2][2]->getMessage());
 
     }
 }

--- a/test/tests/auto/Bukkit/SpigotChunkLoadTest.php
+++ b/test/tests/auto/Bukkit/SpigotChunkLoadTest.php
@@ -5847,7 +5847,32 @@ at net.minecraft.server.v1_13_R1.ChunkProviderServer.generateChunk(ChunkProvider
                     [value:protected] => 1.13
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\ChunkLoadExceptionProblem Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [15:36:38] [Server thread/INFO]: Starting minecraft server version 1.13
+                                            [number:protected] => 7
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [15:36:38] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 204
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\ChunkLoadExceptionProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -6159,10 +6184,12 @@ at net.minecraft.server.v1_13_R1.ChunkProviderServer.generateChunk(ChunkProvider
 
         $this->assertEquals("Minecraft version: 1.13", $analysis[0]->getMessage());
 
-        $this->assertEquals("There was an exception while loading the world chunks.", $analysis[1]->getMessage());
-        $this->assertEquals("Repair the world 'world', e.g. by using Minecraft Region Fixer or MCEdit.", $analysis[1][0]->getMessage());
-        $this->assertEquals("Delete the file 'world'.", $analysis[1][1]->getMessage());
-        $this->assertEquals("Remove the problematic chunk from the world, e.g. with MCEdit or by removing the region file.", $analysis[1][2]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
+
+        $this->assertEquals("There was an exception while loading the world chunks.", $analysis[2]->getMessage());
+        $this->assertEquals("Repair the world 'world', e.g. by using Minecraft Region Fixer or MCEdit.", $analysis[2][0]->getMessage());
+        $this->assertEquals("Delete the file 'world'.", $analysis[2][1]->getMessage());
+        $this->assertEquals("Remove the problematic chunk from the world, e.g. with MCEdit or by removing the region file.", $analysis[2][2]->getMessage());
 
     }
 }

--- a/test/tests/auto/Bukkit/SpigotCommandExceptionTest.php
+++ b/test/tests/auto/Bukkit/SpigotCommandExceptionTest.php
@@ -377,7 +377,32 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
                     [value:protected] => 1.8.8
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginCommandExceptionProblem Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [11:47:42] [Server thread/INFO]: Starting minecraft server version 1.8.8
+                                            [number:protected] => 1
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [11:47:42] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 7
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginCommandExceptionProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -521,7 +546,7 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
 
         )
 
-    [iterator:protected] => 1
+    [iterator:protected] => 2
 )
 ';
         
@@ -530,9 +555,11 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
 
         $this->assertEquals("Minecraft version: 1.8.8", $analysis[0]->getMessage());
 
-        $this->assertEquals("The plugin 'BuildMoney' cannot execute the command '/bm'.", $analysis[1]->getMessage());
-        $this->assertEquals("Install a different version of the plugin 'BuildMoney'.", $analysis[1][0]->getMessage());
-        $this->assertEquals("Remove the plugin 'BuildMoney'.", $analysis[1][1]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
+
+        $this->assertEquals("The plugin 'BuildMoney' cannot execute the command '/bm'.", $analysis[2]->getMessage());
+        $this->assertEquals("Install a different version of the plugin 'BuildMoney'.", $analysis[2][0]->getMessage());
+        $this->assertEquals("Remove the plugin 'BuildMoney'.", $analysis[2][1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Bukkit/SpigotPluginDependencyTest.php
+++ b/test/tests/auto/Bukkit/SpigotPluginDependencyTest.php
@@ -431,7 +431,32 @@ org.bukkit.plugin.UnknownDependencyException: ProtocolLib
                     [value:protected] => 1.8.8
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginDependencyProblem Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [11:47:42] [Server thread/INFO]: Starting minecraft server version 1.8.8
+                                            [number:protected] => 1
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [11:47:42] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 15
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -509,7 +534,7 @@ org.bukkit.plugin.UnknownDependencyException: ProtocolLib
                     [dependencyPluginName:protected] => Vault
                 )
 
-            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginDependencyProblem Object
+            [3] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -589,7 +614,7 @@ org.bukkit.plugin.UnknownDependencyException: ProtocolLib
 
         )
 
-    [iterator:protected] => 2
+    [iterator:protected] => 1
 )
 ';
         
@@ -598,13 +623,15 @@ org.bukkit.plugin.UnknownDependencyException: ProtocolLib
 
         $this->assertEquals("Minecraft version: 1.8.8", $analysis[0]->getMessage());
 
-        $this->assertEquals("The plugin 'FactionsShop' is missing the required the plugin 'Vault'.", $analysis[1]->getMessage());
-        $this->assertEquals("Install the plugin 'Vault'.", $analysis[1][0]->getMessage());
-        $this->assertEquals("Delete the file 'plugins/FactionsShop.jar'.", $analysis[1][1]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
 
-        $this->assertEquals("The plugin 'BasicTab' is missing the required the plugin 'ProtocolLib'.", $analysis[2]->getMessage());
-        $this->assertEquals("Install the plugin 'ProtocolLib'.", $analysis[2][0]->getMessage());
-        $this->assertEquals("Delete the file 'plugins/BasicTab.jar'.", $analysis[2][1]->getMessage());
+        $this->assertEquals("The plugin 'FactionsShop' is missing the required the plugin 'Vault'.", $analysis[2]->getMessage());
+        $this->assertEquals("Install the plugin 'Vault'.", $analysis[2][0]->getMessage());
+        $this->assertEquals("Delete the file 'plugins/FactionsShop.jar'.", $analysis[2][1]->getMessage());
+
+        $this->assertEquals("The plugin 'BasicTab' is missing the required the plugin 'ProtocolLib'.", $analysis[3]->getMessage());
+        $this->assertEquals("Install the plugin 'ProtocolLib'.", $analysis[3][0]->getMessage());
+        $this->assertEquals("Delete the file 'plugins/BasicTab.jar'.", $analysis[3][1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Bukkit/SpigotPluginEnablingTest.php
+++ b/test/tests/auto/Bukkit/SpigotPluginEnablingTest.php
@@ -912,7 +912,32 @@ at java.lang.ClassLoader.loadClass(ClassLoader.java:357) ~[?:1.8.0_144]
                     [value:protected] => 1.13.2
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginEnablingProblem Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [14:33:06] [Server thread/INFO]: Starting minecraft server version 1.13.2
+                                            [number:protected] => 2
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [14:33:06] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 35
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginEnablingProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1094,9 +1119,11 @@ at java.lang.ClassLoader.loadClass(ClassLoader.java:357) ~[?:1.8.0_144]
 
         $this->assertEquals("Minecraft version: 1.13.2", $analysis[0]->getMessage());
 
-        $this->assertEquals("The plugin 'Multiverse-Portals' could not be enabled.", $analysis[1]->getMessage());
-        $this->assertEquals("Install a different version of the plugin 'Multiverse-Portals'.", $analysis[1][0]->getMessage());
-        $this->assertEquals("Remove the plugin 'Multiverse-Portals'.", $analysis[1][1]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
+
+        $this->assertEquals("The plugin 'Multiverse-Portals' could not be enabled.", $analysis[2]->getMessage());
+        $this->assertEquals("Install a different version of the plugin 'Multiverse-Portals'.", $analysis[2][0]->getMessage());
+        $this->assertEquals("Remove the plugin 'Multiverse-Portals'.", $analysis[2][1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Bukkit/SpigotPluginLoadTest.php
+++ b/test/tests/auto/Bukkit/SpigotPluginLoadTest.php
@@ -367,7 +367,32 @@ Caused by: java.lang.NullPointerException
                     [value:protected] => 1.8.8
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginLoadProblem Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [11:47:42] [Server thread/INFO]: Starting minecraft server version 1.8.8
+                                            [number:protected] => 1
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [11:47:42] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 12
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginLoadProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -491,9 +516,11 @@ Caused by: java.lang.NullPointerException
 
         $this->assertEquals("Minecraft version: 1.8.8", $analysis[0]->getMessage());
 
-        $this->assertEquals("The plugin 'GamenixText' could not be loaded.", $analysis[1]->getMessage());
-        $this->assertEquals("Install a different version of the plugin 'GamenixText'.", $analysis[1][0]->getMessage());
-        $this->assertEquals("Delete the file 'plugins/GamenixText.jar'.", $analysis[1][1]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
+
+        $this->assertEquals("The plugin 'GamenixText' could not be loaded.", $analysis[2]->getMessage());
+        $this->assertEquals("Install a different version of the plugin 'GamenixText'.", $analysis[2][0]->getMessage());
+        $this->assertEquals("Delete the file 'plugins/GamenixText.jar'.", $analysis[2][1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Bukkit/SpigotPluginTaskExceptionTest.php
+++ b/test/tests/auto/Bukkit/SpigotPluginTaskExceptionTest.php
@@ -4751,7 +4751,32 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
                     [value:protected] => 1.13.2
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginRuntimeProblem Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [11:22:59] [Server thread/INFO]: Starting minecraft server version 1.13.2
+                                            [number:protected] => 2
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [11:22:59] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 233
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginRuntimeProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -4858,7 +4883,7 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
 
         )
 
-    [iterator:protected] => 1
+    [iterator:protected] => 2
 )
 ';
         
@@ -4867,9 +4892,11 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
 
         $this->assertEquals("Minecraft version: 1.13.2", $analysis[0]->getMessage());
 
-        $this->assertEquals("The plugin 'Essentials' has a problem while running.", $analysis[1]->getMessage());
-        $this->assertEquals("Install a different version of the plugin 'Essentials'.", $analysis[1][0]->getMessage());
-        $this->assertEquals("Remove the plugin 'Essentials'.", $analysis[1][1]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
+
+        $this->assertEquals("The plugin 'Essentials' has a problem while running.", $analysis[2]->getMessage());
+        $this->assertEquals("Install a different version of the plugin 'Essentials'.", $analysis[2][0]->getMessage());
+        $this->assertEquals("Remove the plugin 'Essentials'.", $analysis[2][1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Bukkit/SpigotStart1132Test.php
+++ b/test/tests/auto/Bukkit/SpigotStart1132Test.php
@@ -3608,9 +3608,34 @@ class SpigotStart1132Test extends PHPUnit\Framework\TestCase
                     [value:protected] => 1.13.2
                 )
 
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [23:40:28] [Server thread/INFO]: Starting minecraft server version 1.13.2
+                                            [number:protected] => 2
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [23:40:28] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 185
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
         )
 
-    [iterator:protected] => 0
+    [iterator:protected] => 1
 )
 ';
         
@@ -3618,6 +3643,8 @@ class SpigotStart1132Test extends PHPUnit\Framework\TestCase
         $this->assertEquals($expectedAnalysis, print_r($analysis, true));
 
         $this->assertEquals("Minecraft version: 1.13.2", $analysis[0]->getMessage());
+
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Bukkit/SpigotStart1165Test.php
+++ b/test/tests/auto/Bukkit/SpigotStart1165Test.php
@@ -302,9 +302,34 @@ class SpigotStart1165Test extends PHPUnit\Framework\TestCase
                     [value:protected] => 1.16.5
                 )
 
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [21:42:06] [Server thread/INFO]: Starting minecraft server version 1.16.5
+                                            [number:protected] => 4
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [21:42:06] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 10
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
         )
 
-    [iterator:protected] => 0
+    [iterator:protected] => 1
 )
 ';
         
@@ -312,6 +337,8 @@ class SpigotStart1165Test extends PHPUnit\Framework\TestCase
         $this->assertEquals($expectedAnalysis, print_r($analysis, true));
 
         $this->assertEquals("Minecraft version: 1.16.5", $analysis[0]->getMessage());
+
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Fabric/Fabric1165OriginsTest.php
+++ b/test/tests/auto/Fabric/Fabric1165OriginsTest.php
@@ -372,9 +372,40 @@ class Fabric1165OriginsTest extends PHPUnit\Framework\TestCase
                     [value:protected] => 1.16.5
                 )
 
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [07:28:54] [Server thread/INFO]: Starting minecraft server version 1.16.5
+                                            [number:protected] => 16
+                                        )
+
+                                    [1] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 
+                                            [number:protected] => 17
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [07:28:54] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 1
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
         )
 
-    [iterator:protected] => 0
+    [iterator:protected] => 1
 )
 ';
         
@@ -382,6 +413,8 @@ class Fabric1165OriginsTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($expectedAnalysis, print_r($analysis, true));
 
         $this->assertEquals("Minecraft version: 1.16.5", $analysis[0]->getMessage());
+
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Fabric/Fabric1165Test.php
+++ b/test/tests/auto/Fabric/Fabric1165Test.php
@@ -366,9 +366,34 @@ class Fabric1165Test extends PHPUnit\Framework\TestCase
                     [value:protected] => 1.16.5
                 )
 
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [17:09:31] [Server thread/INFO]: Starting minecraft server version 1.16.5
+                                            [number:protected] => 12
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [17:09:31] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 5
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
         )
 
-    [iterator:protected] => 0
+    [iterator:protected] => 1
 )
 ';
         
@@ -376,6 +401,8 @@ class Fabric1165Test extends PHPUnit\Framework\TestCase
         $this->assertEquals($expectedAnalysis, print_r($analysis, true));
 
         $this->assertEquals("Minecraft version: 1.16.5", $analysis[0]->getMessage());
+
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Fabric/Fabric1181Test.php
+++ b/test/tests/auto/Fabric/Fabric1181Test.php
@@ -2120,9 +2120,34 @@ class Fabric1181Test extends PHPUnit\Framework\TestCase
                     [value:protected] => 17
                 )
 
+            [3] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [01:59:33] [Server thread/INFO]: Starting minecraft server version 1.18.1
+                                            [number:protected] => 16
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [01:59:33] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 13
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
         )
 
-    [iterator:protected] => 0
+    [iterator:protected] => 3
 )
 ';
         
@@ -2134,6 +2159,8 @@ class Fabric1181Test extends PHPUnit\Framework\TestCase
         $this->assertEquals("Fabric loader version: 0.13.3", $analysis[1]->getMessage());
 
         $this->assertEquals("Java version: 17", $analysis[2]->getMessage());
+
+        $this->assertEquals("Environment: Server", $analysis[3]->getMessage());
 
     }
 }

--- a/test/tests/auto/Fabric/FabricEntrypointErrorTest.php
+++ b/test/tests/auto/Fabric/FabricEntrypointErrorTest.php
@@ -1034,7 +1034,248 @@ Caused by: java.lang.NoSuchMethodError: net.minecraft.class_2370: method \'void 
                     [value:protected] => 17
                 )
 
-            [3] => Aternos\Codex\Minecraft\Analysis\Problem\Fabric\FabricEntryStageProblem Object
+            [3] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [22:28:53] [main/ERROR]: Failed to start the minecraft server
+                                            [number:protected] => 47
+                                        )
+
+                                    [1] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => java.lang.RuntimeException: Could not execute entrypoint stage \'main\' due to errors, provided by \'bfapi\'!
+                                            [number:protected] => 48
+                                        )
+
+                                    [2] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at net.fabricmc.loader.impl.entrypoint.EntrypointUtils.lambda$invoke0$0(EntrypointUtils.java:51) ~[fabric-loader-0.13.3.jar:?]
+                                            [number:protected] => 49
+                                        )
+
+                                    [3] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at net.fabricmc.loader.impl.util.ExceptionUtil.gatherExceptions(ExceptionUtil.java:33) ~[fabric-loader-0.13.3.jar:?]
+                                            [number:protected] => 50
+                                        )
+
+                                    [4] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at net.fabricmc.loader.impl.entrypoint.EntrypointUtils.invoke0(EntrypointUtils.java:49) ~[fabric-loader-0.13.3.jar:?]
+                                            [number:protected] => 51
+                                        )
+
+                                    [5] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at net.fabricmc.loader.impl.entrypoint.EntrypointUtils.invoke(EntrypointUtils.java:35) ~[fabric-loader-0.13.3.jar:?]
+                                            [number:protected] => 52
+                                        )
+
+                                    [6] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at net.fabricmc.loader.impl.game.minecraft.Hooks.startServer(Hooks.java:62) ~[fabric-loader-0.13.3.jar:?]
+                                            [number:protected] => 53
+                                        )
+
+                                    [7] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at net.minecraft.server.Main.main(Main.java:101) [server-intermediary.jar:?]
+                                            [number:protected] => 54
+                                        )
+
+                                    [8] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
+                                            [number:protected] => 55
+                                        )
+
+                                    [9] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
+                                            [number:protected] => 56
+                                        )
+
+                                    [10] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
+                                            [number:protected] => 57
+                                        )
+
+                                    [11] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
+                                            [number:protected] => 58
+                                        )
+
+                                    [12] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:416) [fabric-loader-0.13.3.jar:?]
+                                            [number:protected] => 59
+                                        )
+
+                                    [13] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:77) [fabric-loader-0.13.3.jar:?]
+                                            [number:protected] => 60
+                                        )
+
+                                    [14] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at net.fabricmc.loader.impl.launch.knot.KnotServer.main(KnotServer.java:23) [fabric-loader-0.13.3.jar:?]
+                                            [number:protected] => 61
+                                        )
+
+                                    [15] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
+                                            [number:protected] => 62
+                                        )
+
+                                    [16] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
+                                            [number:protected] => 63
+                                        )
+
+                                    [17] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
+                                            [number:protected] => 64
+                                        )
+
+                                    [18] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
+                                            [number:protected] => 65
+                                        )
+
+                                    [19] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at net.fabricmc.loader.impl.launch.server.FabricServerLauncher.main(FabricServerLauncher.java:66) [fabric-loader-0.13.3.jar:?]
+                                            [number:protected] => 66
+                                        )
+
+                                    [20] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => Caused by: java.lang.NoSuchMethodError: net.minecraft.class_2370: method \'void <init>(net.minecraft.class_5321, com.mojang.serialization.Lifecycle)\' not found
+                                            [number:protected] => 67
+                                        )
+
+                                    [21] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at com.bb1.fabric.bfapi.registery.BFAPIRegistry.<init>(BFAPIRegistry.java:104) ~[bfapi.jar:?]
+                                            [number:protected] => 68
+                                        )
+
+                                    [22] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at com.bb1.fabric.bfapi.registery.BFAPIRegistry.<init>(BFAPIRegistry.java:100) ~[bfapi.jar:?]
+                                            [number:protected] => 69
+                                        )
+
+                                    [23] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at com.bb1.fabric.bfapi.registery.BFAPIRegistry.<init>(BFAPIRegistry.java:96) ~[bfapi.jar:?]
+                                            [number:protected] => 70
+                                        )
+
+                                    [24] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at com.bb1.fabric.bfapi.registery.BFAPIRegistry.<init>(BFAPIRegistry.java:92) ~[bfapi.jar:?]
+                                            [number:protected] => 71
+                                        )
+
+                                    [25] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at com.bb1.fabric.bfapi.registery.BFAPIRegistry.<clinit>(BFAPIRegistry.java:42) ~[bfapi.jar:?]
+                                            [number:protected] => 72
+                                        )
+
+                                    [26] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at com.bb1.fabric.bfapi.events.Event.register(Event.java:46) ~[bfapi.jar:?]
+                                            [number:protected] => 73
+                                        )
+
+                                    [27] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at com.bb1.fabric.bfapi.events.Event.<init>(Event.java:33) ~[bfapi.jar:?]
+                                            [number:protected] => 74
+                                        )
+
+                                    [28] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at com.bb1.fabric.bfapi.events.Event.<init>(Event.java:25) ~[bfapi.jar:?]
+                                            [number:protected] => 75
+                                        )
+
+                                    [29] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at com.bb1.fabric.bfapi.Loader.<clinit>(Loader.java:42) ~[bfapi.jar:?]
+                                            [number:protected] => 76
+                                        )
+
+                                    [30] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at java.lang.Class.forName0(Native Method) ~[?:?]
+                                            [number:protected] => 77
+                                        )
+
+                                    [31] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at java.lang.Class.forName(Class.java:467) ~[?:?]
+                                            [number:protected] => 78
+                                        )
+
+                                    [32] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at net.fabricmc.loader.impl.util.DefaultLanguageAdapter.create(DefaultLanguageAdapter.java:50) ~[fabric-loader-0.13.3.jar:?]
+                                            [number:protected] => 79
+                                        )
+
+                                    [33] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at net.fabricmc.loader.impl.entrypoint.EntrypointStorage$NewEntry.getOrCreate(EntrypointStorage.java:117) ~[fabric-loader-0.13.3.jar:?]
+                                            [number:protected] => 80
+                                        )
+
+                                    [34] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at net.fabricmc.loader.impl.entrypoint.EntrypointContainerImpl.getEntrypoint(EntrypointContainerImpl.java:53) ~[fabric-loader-0.13.3.jar:?]
+                                            [number:protected] => 81
+                                        )
+
+                                    [35] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	at net.fabricmc.loader.impl.entrypoint.EntrypointUtils.invoke0(EntrypointUtils.java:47) ~[fabric-loader-0.13.3.jar:?]
+                                            [number:protected] => 82
+                                        )
+
+                                    [36] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 	... 15 more
+                                            [number:protected] => 83
+                                        )
+
+                                )
+
+                            [level:protected] => ERROR
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [22:28:53] [main/ERROR]:
+                        )
+
+                    [counter:protected] => 1
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [4] => Aternos\Codex\Minecraft\Analysis\Problem\Fabric\FabricEntryStageProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1286,7 +1527,7 @@ Caused by: java.lang.NoSuchMethodError: net.minecraft.class_2370: method \'void 
 
         )
 
-    [iterator:protected] => 3
+    [iterator:protected] => 4
 )
 ';
         
@@ -1299,8 +1540,10 @@ Caused by: java.lang.NoSuchMethodError: net.minecraft.class_2370: method \'void 
 
         $this->assertEquals("Java version: 17", $analysis[2]->getMessage());
 
-        $this->assertEquals("The mod 'bfapi' has thrown an exception.", $analysis[3]->getMessage());
-        $this->assertEquals("Remove the mod 'bfapi'.", $analysis[3][0]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[3]->getMessage());
+
+        $this->assertEquals("The mod 'bfapi' has thrown an exception.", $analysis[4]->getMessage());
+        $this->assertEquals("Remove the mod 'bfapi'.", $analysis[4][0]->getMessage());
 
     }
 }

--- a/test/tests/auto/Fabric/FabricJava11Test.php
+++ b/test/tests/auto/Fabric/FabricJava11Test.php
@@ -625,9 +625,34 @@ class FabricJava11Test extends PHPUnit\Framework\TestCase
                     [value:protected] => 11
                 )
 
+            [3] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [14:06:08] [Server thread/INFO]: Starting minecraft server version 1.16.5
+                                            [number:protected] => 12
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [14:06:08] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 15
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
         )
 
-    [iterator:protected] => 0
+    [iterator:protected] => 3
 )
 ';
         
@@ -639,6 +664,8 @@ class FabricJava11Test extends PHPUnit\Framework\TestCase
         $this->assertEquals("Fabric loader version: 0.11.1", $analysis[1]->getMessage());
 
         $this->assertEquals("Java version: 11", $analysis[2]->getMessage());
+
+        $this->assertEquals("Environment: Server", $analysis[3]->getMessage());
 
     }
 }

--- a/test/tests/auto/Fabric/FabricJava8Test.php
+++ b/test/tests/auto/Fabric/FabricJava8Test.php
@@ -625,9 +625,34 @@ class FabricJava8Test extends PHPUnit\Framework\TestCase
                     [value:protected] => 8
                 )
 
+            [3] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [13:33:01] [Server thread/INFO]: Starting minecraft server version 1.16.5
+                                            [number:protected] => 13
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [13:33:01] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 12
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
         )
 
-    [iterator:protected] => 0
+    [iterator:protected] => 3
 )
 ';
         
@@ -639,6 +664,8 @@ class FabricJava8Test extends PHPUnit\Framework\TestCase
         $this->assertEquals("Fabric loader version: 0.11.1", $analysis[1]->getMessage());
 
         $this->assertEquals("Java version: 8", $analysis[2]->getMessage());
+
+        $this->assertEquals("Environment: Server", $analysis[3]->getMessage());
 
     }
 }

--- a/test/tests/auto/Fabric/FabricModNamesTest.php
+++ b/test/tests/auto/Fabric/FabricModNamesTest.php
@@ -3017,9 +3017,34 @@ class FabricModNamesTest extends PHPUnit\Framework\TestCase
                     [value:protected] => 17
                 )
 
+            [3] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [14:47:28] [Server thread/INFO]: Starting minecraft server version 1.18.2
+                                            [number:protected] => 49
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [14:47:28] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 13
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
         )
 
-    [iterator:protected] => 0
+    [iterator:protected] => 3
 )
 ';
         
@@ -3031,6 +3056,8 @@ class FabricModNamesTest extends PHPUnit\Framework\TestCase
         $this->assertEquals("Fabric loader version: 0.13.3", $analysis[1]->getMessage());
 
         $this->assertEquals("Java version: 17", $analysis[2]->getMessage());
+
+        $this->assertEquals("Environment: Server", $analysis[3]->getMessage());
 
     }
 }

--- a/test/tests/auto/Fabric/FabricPreReleaseTest.php
+++ b/test/tests/auto/Fabric/FabricPreReleaseTest.php
@@ -663,9 +663,34 @@ class FabricPreReleaseTest extends PHPUnit\Framework\TestCase
                     [value:protected] => 1.18.2
                 )
 
+            [4] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [11:28:33] [Server thread/INFO]: Starting minecraft server version 1.18.2 Pre-release 3
+                                            [number:protected] => 16
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [11:28:33] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 13
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
         )
 
-    [iterator:protected] => 3
+    [iterator:protected] => 4
 )
 ';
         
@@ -679,6 +704,8 @@ class FabricPreReleaseTest extends PHPUnit\Framework\TestCase
         $this->assertEquals("Java version: 17", $analysis[2]->getMessage());
 
         $this->assertEquals("Minecraft version: 1.18.2", $analysis[3]->getMessage());
+
+        $this->assertEquals("Environment: Server", $analysis[4]->getMessage());
 
     }
 }

--- a/test/tests/auto/Forge/ForgeConfirmTest.php
+++ b/test/tests/auto/Forge/ForgeConfirmTest.php
@@ -105,7 +105,80 @@ Alternatively start the server with -Dfml.queryResult=confirm or -Dfml.queryResu
 (
     [insights:protected] => Array
         (
-            [0] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\FmlConfirmProblem Object
+            [0] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [13:31:32] [Server thread/WARN] [FML/]: Forge Mod Loader detected that the backup level.dat is being used.
+                                            [number:protected] => 1
+                                        )
+
+                                    [1] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 
+                                            [number:protected] => 2
+                                        )
+
+                                    [2] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => This may happen due to a bug or corruption, continuing can damage
+                                            [number:protected] => 3
+                                        )
+
+                                    [3] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => your world beyond repair or lose data / progress.
+                                            [number:protected] => 4
+                                        )
+
+                                    [4] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 
+                                            [number:protected] => 5
+                                        )
+
+                                    [5] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => It\'s recommended to create a world backup before continuing.
+                                            [number:protected] => 6
+                                        )
+
+                                    [6] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 
+                                            [number:protected] => 7
+                                        )
+
+                                    [7] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => Run the command /fml confirm or or /fml cancel to proceed.
+                                            [number:protected] => 8
+                                        )
+
+                                    [8] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => Alternatively start the server with -Dfml.queryResult=confirm or -Dfml.queryResult=cancel to preselect the answer.
+                                            [number:protected] => 9
+                                        )
+
+                                )
+
+                            [level:protected] => WARN
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [13:31:32] [Server thread/WARN] [FML/]:
+                        )
+
+                    [counter:protected] => 1
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\FmlConfirmProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -188,15 +261,17 @@ Alternatively start the server with -Dfml.queryResult=confirm or -Dfml.queryResu
 
         )
 
-    [iterator:protected] => 0
+    [iterator:protected] => 1
 )
 ';
         
         $this->assertEquals($expectedLog, print_r($log, true));
         $this->assertEquals($expectedAnalysis, print_r($analysis, true));
 
-        $this->assertEquals("Forge requires your confirmation to apply changes and start the server.", $analysis[0]->getMessage());
-        $this->assertEquals("Run the command '/fml confirm'.", $analysis[0][0]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[0]->getMessage());
+
+        $this->assertEquals("Forge requires your confirmation to apply changes and start the server.", $analysis[1]->getMessage());
+        $this->assertEquals("Run the command '/fml confirm'.", $analysis[1][0]->getMessage());
 
     }
 }

--- a/test/tests/auto/Forge/ForgeMissingModsExceptionTest.php
+++ b/test/tests/auto/Forge/ForgeMissingModsExceptionTest.php
@@ -2429,7 +2429,32 @@ net.minecraftforge.fml.common.MissingModsException: Mod helicopterpack (Hero Avi
                     [value:protected] => 1.12.2
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVersionInformation Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [14:43:24] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer]: Starting minecraft server version 1.12.2
+                                            [number:protected] => 67
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [14:43:24] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer]:
+                        )
+
+                    [counter:protected] => 54
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVersionInformation Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -2454,7 +2479,7 @@ net.minecraftforge.fml.common.MissingModsException: Mod helicopterpack (Hero Avi
                     [value:protected] => 14.23.5.2860
                 )
 
-            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
+            [3] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -2496,7 +2521,7 @@ net.minecraftforge.fml.common.MissingModsException: Mod helicopterpack (Hero Avi
 
         )
 
-    [iterator:protected] => 2
+    [iterator:protected] => 1
 )
 ';
         
@@ -2505,10 +2530,12 @@ net.minecraftforge.fml.common.MissingModsException: Mod helicopterpack (Hero Avi
 
         $this->assertEquals("Minecraft version: 1.12.2", $analysis[0]->getMessage());
 
-        $this->assertEquals("Forge version: 14.23.5.2860", $analysis[1]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
 
-        $this->assertEquals("The mod 'Hero Aviation Helicopter Pack (HA/HP)' is missing the required mod 'mts'.", $analysis[2]->getMessage());
-        $this->assertEquals("Install the mod 'mts' with version 19.0.0.", $analysis[2][0]->getMessage());
+        $this->assertEquals("Forge version: 14.23.5.2860", $analysis[2]->getMessage());
+
+        $this->assertEquals("The mod 'Hero Aviation Helicopter Pack (HA/HP)' is missing the required mod 'mts'.", $analysis[3]->getMessage());
+        $this->assertEquals("Install the mod 'mts' with version 19.0.0.", $analysis[3][0]->getMessage());
 
     }
 }

--- a/test/tests/auto/Forge/ForgeModDependencyTest.php
+++ b/test/tests/auto/Forge/ForgeModDependencyTest.php
@@ -1251,7 +1251,32 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
                     [value:protected] => 1.12.2
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVersionInformation Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [00:05:11] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer]: Starting minecraft server version 1.12.2
+                                            [number:protected] => 6
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [00:05:11] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer]:
+                        )
+
+                    [counter:protected] => 55
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVersionInformation Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1276,7 +1301,7 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
                     [value:protected] => 14.23.5.2814
                 )
 
-            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
+            [3] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1316,7 +1341,7 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
 
                 )
 
-            [3] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
+            [4] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1356,7 +1381,7 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
 
                 )
 
-            [4] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
+            [5] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1396,7 +1421,7 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
 
                 )
 
-            [5] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
+            [6] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1436,7 +1461,7 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
 
                 )
 
-            [6] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
+            [7] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1476,7 +1501,7 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
 
                 )
 
-            [7] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
+            [8] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1516,7 +1541,7 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
 
                 )
 
-            [8] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
+            [9] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1556,7 +1581,7 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
 
                 )
 
-            [9] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
+            [10] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1596,7 +1621,7 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
 
                 )
 
-            [10] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
+            [11] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1643,7 +1668,7 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
 
                 )
 
-            [11] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
+            [12] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1685,7 +1710,7 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
 
         )
 
-    [iterator:protected] => 11
+    [iterator:protected] => 1
 )
 ';
         
@@ -1694,38 +1719,40 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
 
         $this->assertEquals("Minecraft version: 1.12.2", $analysis[0]->getMessage());
 
-        $this->assertEquals("Forge version: 14.23.5.2814", $analysis[1]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
 
-        $this->assertEquals("The mod 'CoFH Core' is missing the required mod 'redstoneflux'.", $analysis[2]->getMessage());
-        $this->assertEquals("Install the mod 'redstoneflux' with version 2.1.0.", $analysis[2][0]->getMessage());
+        $this->assertEquals("Forge version: 14.23.5.2814", $analysis[2]->getMessage());
 
-        $this->assertEquals("The mod 'Thermal Dynamics' is missing the required mod 'codechickenlib'.", $analysis[3]->getMessage());
-        $this->assertEquals("Install the mod 'codechickenlib' with version 3.2.2.", $analysis[3][0]->getMessage());
+        $this->assertEquals("The mod 'CoFH Core' is missing the required mod 'redstoneflux'.", $analysis[3]->getMessage());
+        $this->assertEquals("Install the mod 'redstoneflux' with version 2.1.0.", $analysis[3][0]->getMessage());
 
-        $this->assertEquals("The mod 'EvilCraft' is missing the required mod 'cyclopscore'.", $analysis[4]->getMessage());
-        $this->assertEquals("Install the mod 'cyclopscore' with version 1.0.0.", $analysis[4][0]->getMessage());
+        $this->assertEquals("The mod 'Thermal Dynamics' is missing the required mod 'codechickenlib'.", $analysis[4]->getMessage());
+        $this->assertEquals("Install the mod 'codechickenlib' with version 3.2.2.", $analysis[4][0]->getMessage());
 
-        $this->assertEquals("The mod 'EvilCraft-Compat' is missing the required mod 'cyclopscore'.", $analysis[5]->getMessage());
-        $this->assertEquals("Install the mod 'cyclopscore' with version 0.11.6.", $analysis[5][0]->getMessage());
+        $this->assertEquals("The mod 'EvilCraft' is missing the required mod 'cyclopscore'.", $analysis[5]->getMessage());
+        $this->assertEquals("Install the mod 'cyclopscore' with version 1.0.0.", $analysis[5][0]->getMessage());
 
-        $this->assertEquals("The mod 'Applied Energistics 2' is missing the required mod 'forge'.", $analysis[6]->getMessage());
-        $this->assertEquals("Install the mod 'forge' with version 14.23.5.2768.", $analysis[6][0]->getMessage());
+        $this->assertEquals("The mod 'EvilCraft-Compat' is missing the required mod 'cyclopscore'.", $analysis[6]->getMessage());
+        $this->assertEquals("Install the mod 'cyclopscore' with version 0.11.6.", $analysis[6][0]->getMessage());
 
-        $this->assertEquals("The mod 'Ex Nihilo Creatio' is missing the required mod 'forgelin'.", $analysis[7]->getMessage());
-        $this->assertEquals("Install the mod 'forgelin'.", $analysis[7][0]->getMessage());
+        $this->assertEquals("The mod 'Applied Energistics 2' is missing the required mod 'forge'.", $analysis[7]->getMessage());
+        $this->assertEquals("Install the mod 'forge' with version 14.23.5.2768.", $analysis[7][0]->getMessage());
 
-        $this->assertEquals("The mod 'Clay Soldiers Mod' is missing the required mod 'sanlib'.", $analysis[8]->getMessage());
-        $this->assertEquals("Install the mod 'sanlib' with version 1.2.0.", $analysis[8][0]->getMessage());
+        $this->assertEquals("The mod 'Ex Nihilo Creatio' is missing the required mod 'forgelin'.", $analysis[8]->getMessage());
+        $this->assertEquals("Install the mod 'forgelin'.", $analysis[8][0]->getMessage());
 
-        $this->assertEquals("The mod 'Biomes O' Plenty' is missing the required mod 'forge'.", $analysis[9]->getMessage());
-        $this->assertEquals("Install the mod 'forge' with version 14.23.5.2768.", $analysis[9][0]->getMessage());
+        $this->assertEquals("The mod 'Clay Soldiers Mod' is missing the required mod 'sanlib'.", $analysis[9]->getMessage());
+        $this->assertEquals("Install the mod 'sanlib' with version 1.2.0.", $analysis[9][0]->getMessage());
 
-        $this->assertEquals("The mod 'Forge Multipart CBE' is missing the required mods 'codechickenlib', 'forge'.", $analysis[10]->getMessage());
-        $this->assertEquals("Install the mod 'codechickenlib' with version 3.2.2.", $analysis[10][0]->getMessage());
-        $this->assertEquals("Install the mod 'forge' with version 14.23.5.2768.", $analysis[10][1]->getMessage());
+        $this->assertEquals("The mod 'Biomes O' Plenty' is missing the required mod 'forge'.", $analysis[10]->getMessage());
+        $this->assertEquals("Install the mod 'forge' with version 14.23.5.2768.", $analysis[10][0]->getMessage());
 
-        $this->assertEquals("The mod 'Dragon Mounts' is missing the required mod 'llibrary'.", $analysis[11]->getMessage());
-        $this->assertEquals("Install the mod 'llibrary' with version 1.7.9.", $analysis[11][0]->getMessage());
+        $this->assertEquals("The mod 'Forge Multipart CBE' is missing the required mods 'codechickenlib', 'forge'.", $analysis[11]->getMessage());
+        $this->assertEquals("Install the mod 'codechickenlib' with version 3.2.2.", $analysis[11][0]->getMessage());
+        $this->assertEquals("Install the mod 'forge' with version 14.23.5.2768.", $analysis[11][1]->getMessage());
+
+        $this->assertEquals("The mod 'Dragon Mounts' is missing the required mod 'llibrary'.", $analysis[12]->getMessage());
+        $this->assertEquals("Install the mod 'llibrary' with version 1.7.9.", $analysis[12][0]->getMessage());
 
     }
 }

--- a/test/tests/auto/Forge/ForgeModDuplicateTest.php
+++ b/test/tests/auto/Forge/ForgeModDuplicateTest.php
@@ -5941,7 +5941,32 @@ class ForgeModDuplicateTest extends PHPUnit\Framework\TestCase
 (
     [insights:protected] => Array
         (
-            [0] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVersionInformation Object
+            [0] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [22:32:38] [Server thread/INFO] [MinecraftForge/]: Attempting early MinecraftForge initialization
+                                            [number:protected] => 167
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [22:32:38] [Server thread/INFO] [MinecraftForge/]:
+                        )
+
+                    [counter:protected] => 147
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVersionInformation Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -5966,7 +5991,7 @@ class ForgeModDuplicateTest extends PHPUnit\Framework\TestCase
                     [value:protected] => 10.13.4.1614
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDuplicateProblem Object
+            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDuplicateProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -6011,18 +6036,20 @@ class ForgeModDuplicateTest extends PHPUnit\Framework\TestCase
 
         )
 
-    [iterator:protected] => 1
+    [iterator:protected] => 0
 )
 ';
         
         $this->assertEquals($expectedLog, print_r($log, true));
         $this->assertEquals($expectedAnalysis, print_r($analysis, true));
 
-        $this->assertEquals("Forge version: 10.13.4.1614", $analysis[0]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[0]->getMessage());
 
-        $this->assertEquals("There are multiple mod files for the mod name 'Baubles': 'Baubles-1.7.10-1.0.1.10.jar' and 'Baubles-1.7.10-1.0.1.10.jar'.", $analysis[1]->getMessage());
-        $this->assertEquals("Delete the file '/aternos/server/mods/1.7.10/Baubles-1.7.10-1.0.1.10.jar'.", $analysis[1][0]->getMessage());
-        $this->assertEquals("Delete the file '/aternos/server/mods/Baubles-1.7.10-1.0.1.10.jar'.", $analysis[1][1]->getMessage());
+        $this->assertEquals("Forge version: 10.13.4.1614", $analysis[1]->getMessage());
+
+        $this->assertEquals("There are multiple mod files for the mod name 'Baubles': 'Baubles-1.7.10-1.0.1.10.jar' and 'Baubles-1.7.10-1.0.1.10.jar'.", $analysis[2]->getMessage());
+        $this->assertEquals("Delete the file '/aternos/server/mods/1.7.10/Baubles-1.7.10-1.0.1.10.jar'.", $analysis[2][0]->getMessage());
+        $this->assertEquals("Delete the file '/aternos/server/mods/Baubles-1.7.10-1.0.1.10.jar'.", $analysis[2][1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Forge/ForgeModExceptionTest.php
+++ b/test/tests/auto/Forge/ForgeModExceptionTest.php
@@ -6144,7 +6144,32 @@ at java.lang.ClassLoader.loadClass(ClassLoader.java:357) ~[?:1.8.0_144]
 (
     [insights:protected] => Array
         (
-            [0] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVersionInformation Object
+            [0] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [22:50:26] [Server thread/INFO] [MinecraftForge/]: Attempting early MinecraftForge initialization
+                                            [number:protected] => 54
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [22:50:26] [Server thread/INFO] [MinecraftForge/]:
+                        )
+
+                    [counter:protected] => 250
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVersionInformation Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -6169,7 +6194,7 @@ at java.lang.ClassLoader.loadClass(ClassLoader.java:357) ~[?:1.8.0_144]
                     [value:protected] => 10.13.4.1614
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModFatalProblem Object
+            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModFatalProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -6266,7 +6291,7 @@ at java.lang.ClassLoader.loadClass(ClassLoader.java:357) ~[?:1.8.0_144]
                     [modId:protected] => xaerominimap
                 )
 
-            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModExceptionProblem Object
+            [3] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModExceptionProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -6557,7 +6582,7 @@ at java.lang.ClassLoader.loadClass(ClassLoader.java:357) ~[?:1.8.0_144]
                     [modName:protected] => xaerominimap
                 )
 
-            [3] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModExceptionProblem Object
+            [4] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModExceptionProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -6598,26 +6623,28 @@ at java.lang.ClassLoader.loadClass(ClassLoader.java:357) ~[?:1.8.0_144]
 
         )
 
-    [iterator:protected] => 3
+    [iterator:protected] => 0
 )
 ';
         
         $this->assertEquals($expectedLog, print_r($log, true));
         $this->assertEquals($expectedAnalysis, print_r($analysis, true));
 
-        $this->assertEquals("Forge version: 10.13.4.1614", $analysis[0]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[0]->getMessage());
 
-        $this->assertEquals("The mod 'Xaero's Minimap' has a fatal error.", $analysis[1]->getMessage());
-        $this->assertEquals("Delete the file 'mods/Xaeros_Minimap_1.16_Forge_1.7.10.jar'.", $analysis[1][0]->getMessage());
-        $this->assertEquals("Install a different version of the mod 'Xaero's Minimap'.", $analysis[1][1]->getMessage());
+        $this->assertEquals("Forge version: 10.13.4.1614", $analysis[1]->getMessage());
 
-        $this->assertEquals("The mod 'xaerominimap' has thrown an exception.", $analysis[2]->getMessage());
-        $this->assertEquals("Install a different version of the mod 'xaerominimap'.", $analysis[2][0]->getMessage());
-        $this->assertEquals("Remove the mod 'xaerominimap'.", $analysis[2][1]->getMessage());
+        $this->assertEquals("The mod 'Xaero's Minimap' has a fatal error.", $analysis[2]->getMessage());
+        $this->assertEquals("Delete the file 'mods/Xaeros_Minimap_1.16_Forge_1.7.10.jar'.", $analysis[2][0]->getMessage());
+        $this->assertEquals("Install a different version of the mod 'Xaero's Minimap'.", $analysis[2][1]->getMessage());
 
-        $this->assertEquals("The mod 'Discord Chat' has thrown an exception.", $analysis[3]->getMessage());
-        $this->assertEquals("Install a different version of the mod 'Discord Chat'.", $analysis[3][0]->getMessage());
-        $this->assertEquals("Remove the mod 'Discord Chat'.", $analysis[3][1]->getMessage());
+        $this->assertEquals("The mod 'xaerominimap' has thrown an exception.", $analysis[3]->getMessage());
+        $this->assertEquals("Install a different version of the mod 'xaerominimap'.", $analysis[3][0]->getMessage());
+        $this->assertEquals("Remove the mod 'xaerominimap'.", $analysis[3][1]->getMessage());
+
+        $this->assertEquals("The mod 'Discord Chat' has thrown an exception.", $analysis[4]->getMessage());
+        $this->assertEquals("Install a different version of the mod 'Discord Chat'.", $analysis[4][0]->getMessage());
+        $this->assertEquals("Remove the mod 'Discord Chat'.", $analysis[4][1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Forge/ForgeModFatalTest.php
+++ b/test/tests/auto/Forge/ForgeModFatalTest.php
@@ -404,7 +404,32 @@ class ForgeModFatalTest extends PHPUnit\Framework\TestCase
 (
     [insights:protected] => Array
         (
-            [0] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModFatalProblem Object
+            [0] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [18:59:01] [Server thread/ERROR] [FML/]: Fatal errors were detected during the transition from PREINITIALIZATION to INITIALIZATION. Loading cannot continue
+                                            [number:protected] => 1
+                                        )
+
+                                )
+
+                            [level:protected] => ERROR
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [18:59:01] [Server thread/ERROR] [FML/]:
+                        )
+
+                    [counter:protected] => 2
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModFatalProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -737,16 +762,18 @@ class ForgeModFatalTest extends PHPUnit\Framework\TestCase
 
         )
 
-    [iterator:protected] => 0
+    [iterator:protected] => 1
 )
 ';
         
         $this->assertEquals($expectedLog, print_r($log, true));
         $this->assertEquals($expectedAnalysis, print_r($analysis, true));
 
-        $this->assertEquals("The mod 'Techguns' has a fatal error.", $analysis[0]->getMessage());
-        $this->assertEquals("Delete the file 'mods/Techguns.beta.1.2_alphatest4.1.jar'.", $analysis[0][0]->getMessage());
-        $this->assertEquals("Install a different version of the mod 'Techguns'.", $analysis[0][1]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[0]->getMessage());
+
+        $this->assertEquals("The mod 'Techguns' has a fatal error.", $analysis[1]->getMessage());
+        $this->assertEquals("Delete the file 'mods/Techguns.beta.1.2_alphatest4.1.jar'.", $analysis[1][0]->getMessage());
+        $this->assertEquals("Install a different version of the mod 'Techguns'.", $analysis[1][1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Forge/ForgeModRequiredTest.php
+++ b/test/tests/auto/Forge/ForgeModRequiredTest.php
@@ -8138,7 +8138,32 @@ class ForgeModRequiredTest extends PHPUnit\Framework\TestCase
 (
     [insights:protected] => Array
         (
-            [0] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVersionInformation Object
+            [0] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [03:23:36] [Server thread/INFO] [MinecraftForge/]: Attempting early MinecraftForge initialization
+                                            [number:protected] => 76
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [03:23:36] [Server thread/INFO] [MinecraftForge/]:
+                        )
+
+                    [counter:protected] => 353
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVersionInformation Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -8163,7 +8188,7 @@ class ForgeModRequiredTest extends PHPUnit\Framework\TestCase
                     [value:protected] => 10.13.4.1614
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
+            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -8205,17 +8230,19 @@ class ForgeModRequiredTest extends PHPUnit\Framework\TestCase
 
         )
 
-    [iterator:protected] => 1
+    [iterator:protected] => 0
 )
 ';
         
         $this->assertEquals($expectedLog, print_r($log, true));
         $this->assertEquals($expectedAnalysis, print_r($analysis, true));
 
-        $this->assertEquals("Forge version: 10.13.4.1614", $analysis[0]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[0]->getMessage());
 
-        $this->assertEquals("The mod 'Archimedes' Ships Plus' is missing the required mod 'MovingWorld'.", $analysis[1]->getMessage());
-        $this->assertEquals("Install the mod 'MovingWorld'.", $analysis[1][0]->getMessage());
+        $this->assertEquals("Forge version: 10.13.4.1614", $analysis[1]->getMessage());
+
+        $this->assertEquals("The mod 'Archimedes' Ships Plus' is missing the required mod 'MovingWorld'.", $analysis[2]->getMessage());
+        $this->assertEquals("Install the mod 'MovingWorld'.", $analysis[2][0]->getMessage());
 
     }
 }

--- a/test/tests/auto/Forge/ForgeModWrongMinecraftVersionTest.php
+++ b/test/tests/auto/Forge/ForgeModWrongMinecraftVersionTest.php
@@ -9720,7 +9720,32 @@ class ForgeModWrongMinecraftVersionTest extends PHPUnit\Framework\TestCase
 (
     [insights:protected] => Array
         (
-            [0] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVersionInformation Object
+            [0] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [13:41:58] [Server thread/INFO] [FML/]: MinecraftForge v12.18.3.2511 Initialized
+                                            [number:protected] => 280
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [13:41:58] [Server thread/INFO] [FML/]:
+                        )
+
+                    [counter:protected] => 231
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVersionInformation Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -9745,7 +9770,7 @@ class ForgeModWrongMinecraftVersionTest extends PHPUnit\Framework\TestCase
                     [value:protected] => 12.18.3.2511
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModWrongMinecraftVersionProblem Object
+            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModWrongMinecraftVersionProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -9786,18 +9811,20 @@ class ForgeModWrongMinecraftVersionTest extends PHPUnit\Framework\TestCase
 
         )
 
-    [iterator:protected] => 1
+    [iterator:protected] => 0
 )
 ';
         
         $this->assertEquals($expectedLog, print_r($log, true));
         $this->assertEquals($expectedAnalysis, print_r($analysis, true));
 
-        $this->assertEquals("Forge version: 12.18.3.2511", $analysis[0]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[0]->getMessage());
 
-        $this->assertEquals("The mod 'journeymap' is not compatible with the Minecraft version 1.10.2.", $analysis[1]->getMessage());
-        $this->assertEquals("Remove the mod 'journeymap'.", $analysis[1][0]->getMessage());
-        $this->assertEquals("Install a different Forge version.", $analysis[1][1]->getMessage());
+        $this->assertEquals("Forge version: 12.18.3.2511", $analysis[1]->getMessage());
+
+        $this->assertEquals("The mod 'journeymap' is not compatible with the Minecraft version 1.10.2.", $analysis[2]->getMessage());
+        $this->assertEquals("Remove the mod 'journeymap'.", $analysis[2][0]->getMessage());
+        $this->assertEquals("Install a different Forge version.", $analysis[2][1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Forge/ForgePtrlibDependencyTest.php
+++ b/test/tests/auto/Forge/ForgePtrlibDependencyTest.php
@@ -13518,7 +13518,32 @@ at java.lang.ClassLoader.loadClass(ClassLoader.java:351) ~[?:1.8.0_232]
                     [value:protected] => 1.12.2
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVersionInformation Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [17:03:51] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer]: Starting minecraft server version 1.12.2
+                                            [number:protected] => 178
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [17:03:51] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer]:
+                        )
+
+                    [counter:protected] => 513
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVersionInformation Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -13543,7 +13568,7 @@ at java.lang.ClassLoader.loadClass(ClassLoader.java:351) ~[?:1.8.0_232]
                     [value:protected] => 14.23.5.2847
                 )
 
-            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\PTRLibDependencyProblem Object
+            [3] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\PTRLibDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -13850,7 +13875,7 @@ at java.lang.ClassLoader.loadClass(ClassLoader.java:351) ~[?:1.8.0_232]
 
         )
 
-    [iterator:protected] => 2
+    [iterator:protected] => 1
 )
 ';
         
@@ -13859,10 +13884,12 @@ at java.lang.ClassLoader.loadClass(ClassLoader.java:351) ~[?:1.8.0_232]
 
         $this->assertEquals("Minecraft version: 1.12.2", $analysis[0]->getMessage());
 
-        $this->assertEquals("Forge version: 14.23.5.2847", $analysis[1]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
 
-        $this->assertEquals("A mod is missing the required mod PTRLib.", $analysis[2]->getMessage());
-        $this->assertEquals("Install the mod 'PTRLib'.", $analysis[2][0]->getMessage());
+        $this->assertEquals("Forge version: 14.23.5.2847", $analysis[2]->getMessage());
+
+        $this->assertEquals("A mod is missing the required mod PTRLib.", $analysis[3]->getMessage());
+        $this->assertEquals("Install the mod 'PTRLib'.", $analysis[3][0]->getMessage());
 
     }
 }

--- a/test/tests/auto/Forge/ForgeSlashInThreadTest.php
+++ b/test/tests/auto/Forge/ForgeSlashInThreadTest.php
@@ -832,6 +832,31 @@ at net.minecraft.nbt.NBTTagCompound.func_152449_a(NBTTagCompound.java:496) ~[fy.
 (
     [insights:protected] => Array
         (
+            [0] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [09:52:01] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer]: player joined the game
+                                            [number:protected] => 1
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [09:52:01] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer]:
+                        )
+
+                    [counter:protected] => 10
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
         )
 
     [iterator:protected] => 0
@@ -840,6 +865,8 @@ at net.minecraft.nbt.NBTTagCompound.func_152449_a(NBTTagCompound.java:496) ~[fy.
         
         $this->assertEquals($expectedLog, print_r($log, true));
         $this->assertEquals($expectedAnalysis, print_r($analysis, true));
+
+        $this->assertEquals("Environment: Server", $analysis[0]->getMessage());
 
     }
 }

--- a/test/tests/auto/Forge/ForgeStart1122Test.php
+++ b/test/tests/auto/Forge/ForgeStart1122Test.php
@@ -1518,7 +1518,32 @@ class ForgeStart1122Test extends PHPUnit\Framework\TestCase
                     [value:protected] => 1.12.2
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVersionInformation Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [00:37:06] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer]: Starting minecraft server version 1.12.2
+                                            [number:protected] => 7
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [00:37:06] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer]:
+                        )
+
+                    [counter:protected] => 68
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVersionInformation Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1554,7 +1579,9 @@ class ForgeStart1122Test extends PHPUnit\Framework\TestCase
 
         $this->assertEquals("Minecraft version: 1.12.2", $analysis[0]->getMessage());
 
-        $this->assertEquals("Forge version: 14.23.5.2814", $analysis[1]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
+
+        $this->assertEquals("Forge version: 14.23.5.2814", $analysis[2]->getMessage());
 
     }
 }

--- a/test/tests/auto/Forge/ForgeWorldMissingModTest.php
+++ b/test/tests/auto/Forge/ForgeWorldMissingModTest.php
@@ -6494,7 +6494,32 @@ class ForgeWorldMissingModTest extends PHPUnit\Framework\TestCase
 (
     [insights:protected] => Array
         (
-            [0] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVersionInformation Object
+            [0] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [21:33:19] [Server thread/INFO] [FML/]: MinecraftForge v11.15.1.2318 Initialized
+                                            [number:protected] => 59
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [21:33:19] [Server thread/INFO] [FML/]:
+                        )
+
+                    [counter:protected] => 263
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVersionInformation Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -6519,7 +6544,7 @@ class ForgeWorldMissingModTest extends PHPUnit\Framework\TestCase
                     [value:protected] => 11.15.1.2318
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\WorldModVersionProblem Object
+            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\WorldModVersionProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -6560,7 +6585,7 @@ class ForgeWorldMissingModTest extends PHPUnit\Framework\TestCase
                     [expectedVersion:protected] => 9.42
                 )
 
-            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\WorldMissingModProblem Object
+            [3] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\WorldMissingModProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -6601,22 +6626,24 @@ class ForgeWorldMissingModTest extends PHPUnit\Framework\TestCase
 
         )
 
-    [iterator:protected] => 2
+    [iterator:protected] => 0
 )
 ';
         
         $this->assertEquals($expectedLog, print_r($log, true));
         $this->assertEquals($expectedAnalysis, print_r($analysis, true));
 
-        $this->assertEquals("Forge version: 11.15.1.2318", $analysis[0]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[0]->getMessage());
 
-        $this->assertEquals("This world was saved with mod 'mcp' version 9.42 and it is now at version 9.19.", $analysis[1]->getMessage());
-        $this->assertEquals("Install the mod 'mcp' with version 9.42.", $analysis[1][0]->getMessage());
-        $this->assertEquals("Do nothing. This problem might fix itself.", $analysis[1][1]->getMessage());
+        $this->assertEquals("Forge version: 11.15.1.2318", $analysis[1]->getMessage());
 
-        $this->assertEquals("The world was saved with mod 'lucraftcore' which appears to be missing.", $analysis[2]->getMessage());
-        $this->assertEquals("Install the mod 'lucraftcore'.", $analysis[2][0]->getMessage());
+        $this->assertEquals("This world was saved with mod 'mcp' version 9.42 and it is now at version 9.19.", $analysis[2]->getMessage());
+        $this->assertEquals("Install the mod 'mcp' with version 9.42.", $analysis[2][0]->getMessage());
         $this->assertEquals("Do nothing. This problem might fix itself.", $analysis[2][1]->getMessage());
+
+        $this->assertEquals("The world was saved with mod 'lucraftcore' which appears to be missing.", $analysis[3]->getMessage());
+        $this->assertEquals("Install the mod 'lucraftcore'.", $analysis[3][0]->getMessage());
+        $this->assertEquals("Do nothing. This problem might fix itself.", $analysis[3][1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Forge/ForgeWorldModVersionTest.php
+++ b/test/tests/auto/Forge/ForgeWorldModVersionTest.php
@@ -2392,7 +2392,32 @@ class ForgeWorldModVersionTest extends PHPUnit\Framework\TestCase
                     [value:protected] => 1.12.2
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVersionInformation Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [16:48:56] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer]: Starting minecraft server version 1.12.2
+                                            [number:protected] => 18
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [16:48:56] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer]:
+                        )
+
+                    [counter:protected] => 101
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVersionInformation Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -2417,7 +2442,7 @@ class ForgeWorldModVersionTest extends PHPUnit\Framework\TestCase
                     [value:protected] => 14.23.5.2811
                 )
 
-            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\WorldModVersionProblem Object
+            [3] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\WorldModVersionProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -2460,7 +2485,7 @@ class ForgeWorldModVersionTest extends PHPUnit\Framework\TestCase
 
         )
 
-    [iterator:protected] => 2
+    [iterator:protected] => 1
 )
 ';
         
@@ -2469,11 +2494,13 @@ class ForgeWorldModVersionTest extends PHPUnit\Framework\TestCase
 
         $this->assertEquals("Minecraft version: 1.12.2", $analysis[0]->getMessage());
 
-        $this->assertEquals("Forge version: 14.23.5.2811", $analysis[1]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
 
-        $this->assertEquals("This world was saved with mod 'betterbuilderswands' version 0.13.0 and it is now at version 0.11.1.", $analysis[2]->getMessage());
-        $this->assertEquals("Install the mod 'betterbuilderswands' with version 0.13.0.", $analysis[2][0]->getMessage());
-        $this->assertEquals("Do nothing. This problem might fix itself.", $analysis[2][1]->getMessage());
+        $this->assertEquals("Forge version: 14.23.5.2811", $analysis[2]->getMessage());
+
+        $this->assertEquals("This world was saved with mod 'betterbuilderswands' version 0.13.0 and it is now at version 0.11.1.", $analysis[3]->getMessage());
+        $this->assertEquals("Install the mod 'betterbuilderswands' with version 0.13.0.", $analysis[3][0]->getMessage());
+        $this->assertEquals("Do nothing. This problem might fix itself.", $analysis[3][1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Magma/MagmaModDependencyTest.php
+++ b/test/tests/auto/Magma/MagmaModDependencyTest.php
@@ -1245,7 +1245,32 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
 (
     [insights:protected] => Array
         (
-            [0] => Aternos\Codex\Minecraft\Analysis\Information\Magma\MagmaVersionInformation Object
+            [0] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [15:02:53] [Server thread/INFO] [Minecraft]: This server is running Magma version e2b9ab6 (MC: 1.12.2) (Implementing API version 1.12.2-R0.1-SNAPSHOT)
+                                            [number:protected] => 6
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [15:02:53] [Server thread/INFO] [Minecraft]:
+                        )
+
+                    [counter:protected] => 56
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Magma\MagmaVersionInformation Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1270,7 +1295,7 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
                     [value:protected] => e2b9ab6
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVanillaVersionInformation Object
+            [2] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVanillaVersionInformation Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1295,7 +1320,7 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
                     [value:protected] => 1.12.2
                 )
 
-            [2] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVersionInformation Object
+            [3] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVersionInformation Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1320,7 +1345,7 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
                     [value:protected] => 14.23.5.2814
                 )
 
-            [3] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
+            [4] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1360,7 +1385,7 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
 
                 )
 
-            [4] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
+            [5] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1400,7 +1425,7 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
 
                 )
 
-            [5] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
+            [6] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1440,7 +1465,7 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
 
                 )
 
-            [6] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
+            [7] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1480,7 +1505,7 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
 
                 )
 
-            [7] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
+            [8] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1520,7 +1545,7 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
 
                 )
 
-            [8] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
+            [9] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1560,7 +1585,7 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
 
                 )
 
-            [9] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
+            [10] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1600,7 +1625,7 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
 
                 )
 
-            [10] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
+            [11] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1640,7 +1665,7 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
 
                 )
 
-            [11] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
+            [12] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1687,7 +1712,7 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
 
                 )
 
-            [12] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
+            [13] => Aternos\Codex\Minecraft\Analysis\Problem\Forge\ModDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1729,49 +1754,51 @@ net.minecraftforge.fml.common.MissingModsException: Mod dragonmounts (Dragon Mou
 
         )
 
-    [iterator:protected] => 12
+    [iterator:protected] => 0
 )
 ';
         
         $this->assertEquals($expectedLog, print_r($log, true));
         $this->assertEquals($expectedAnalysis, print_r($analysis, true));
 
-        $this->assertEquals("Magma version: e2b9ab6", $analysis[0]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[0]->getMessage());
 
-        $this->assertEquals("Minecraft version: 1.12.2", $analysis[1]->getMessage());
+        $this->assertEquals("Magma version: e2b9ab6", $analysis[1]->getMessage());
 
-        $this->assertEquals("Forge version: 14.23.5.2814", $analysis[2]->getMessage());
+        $this->assertEquals("Minecraft version: 1.12.2", $analysis[2]->getMessage());
 
-        $this->assertEquals("The mod 'CoFH Core' is missing the required mod 'redstoneflux'.", $analysis[3]->getMessage());
-        $this->assertEquals("Install the mod 'redstoneflux' with version 2.1.0.", $analysis[3][0]->getMessage());
+        $this->assertEquals("Forge version: 14.23.5.2814", $analysis[3]->getMessage());
 
-        $this->assertEquals("The mod 'Thermal Dynamics' is missing the required mod 'codechickenlib'.", $analysis[4]->getMessage());
-        $this->assertEquals("Install the mod 'codechickenlib' with version 3.2.2.", $analysis[4][0]->getMessage());
+        $this->assertEquals("The mod 'CoFH Core' is missing the required mod 'redstoneflux'.", $analysis[4]->getMessage());
+        $this->assertEquals("Install the mod 'redstoneflux' with version 2.1.0.", $analysis[4][0]->getMessage());
 
-        $this->assertEquals("The mod 'EvilCraft' is missing the required mod 'cyclopscore'.", $analysis[5]->getMessage());
-        $this->assertEquals("Install the mod 'cyclopscore' with version 1.0.0.", $analysis[5][0]->getMessage());
+        $this->assertEquals("The mod 'Thermal Dynamics' is missing the required mod 'codechickenlib'.", $analysis[5]->getMessage());
+        $this->assertEquals("Install the mod 'codechickenlib' with version 3.2.2.", $analysis[5][0]->getMessage());
 
-        $this->assertEquals("The mod 'EvilCraft-Compat' is missing the required mod 'cyclopscore'.", $analysis[6]->getMessage());
-        $this->assertEquals("Install the mod 'cyclopscore' with version 0.11.6.", $analysis[6][0]->getMessage());
+        $this->assertEquals("The mod 'EvilCraft' is missing the required mod 'cyclopscore'.", $analysis[6]->getMessage());
+        $this->assertEquals("Install the mod 'cyclopscore' with version 1.0.0.", $analysis[6][0]->getMessage());
 
-        $this->assertEquals("The mod 'Applied Energistics 2' is missing the required mod 'forge'.", $analysis[7]->getMessage());
-        $this->assertEquals("Install the mod 'forge' with version 14.23.5.2768.", $analysis[7][0]->getMessage());
+        $this->assertEquals("The mod 'EvilCraft-Compat' is missing the required mod 'cyclopscore'.", $analysis[7]->getMessage());
+        $this->assertEquals("Install the mod 'cyclopscore' with version 0.11.6.", $analysis[7][0]->getMessage());
 
-        $this->assertEquals("The mod 'Ex Nihilo Creatio' is missing the required mod 'forgelin'.", $analysis[8]->getMessage());
-        $this->assertEquals("Install the mod 'forgelin'.", $analysis[8][0]->getMessage());
+        $this->assertEquals("The mod 'Applied Energistics 2' is missing the required mod 'forge'.", $analysis[8]->getMessage());
+        $this->assertEquals("Install the mod 'forge' with version 14.23.5.2768.", $analysis[8][0]->getMessage());
 
-        $this->assertEquals("The mod 'Clay Soldiers Mod' is missing the required mod 'sanlib'.", $analysis[9]->getMessage());
-        $this->assertEquals("Install the mod 'sanlib' with version 1.2.0.", $analysis[9][0]->getMessage());
+        $this->assertEquals("The mod 'Ex Nihilo Creatio' is missing the required mod 'forgelin'.", $analysis[9]->getMessage());
+        $this->assertEquals("Install the mod 'forgelin'.", $analysis[9][0]->getMessage());
 
-        $this->assertEquals("The mod 'Biomes O' Plenty' is missing the required mod 'forge'.", $analysis[10]->getMessage());
-        $this->assertEquals("Install the mod 'forge' with version 14.23.5.2768.", $analysis[10][0]->getMessage());
+        $this->assertEquals("The mod 'Clay Soldiers Mod' is missing the required mod 'sanlib'.", $analysis[10]->getMessage());
+        $this->assertEquals("Install the mod 'sanlib' with version 1.2.0.", $analysis[10][0]->getMessage());
 
-        $this->assertEquals("The mod 'Forge Multipart CBE' is missing the required mods 'codechickenlib', 'forge'.", $analysis[11]->getMessage());
-        $this->assertEquals("Install the mod 'codechickenlib' with version 3.2.2.", $analysis[11][0]->getMessage());
-        $this->assertEquals("Install the mod 'forge' with version 14.23.5.2768.", $analysis[11][1]->getMessage());
+        $this->assertEquals("The mod 'Biomes O' Plenty' is missing the required mod 'forge'.", $analysis[11]->getMessage());
+        $this->assertEquals("Install the mod 'forge' with version 14.23.5.2768.", $analysis[11][0]->getMessage());
 
-        $this->assertEquals("The mod 'Dragon Mounts' is missing the required mod 'llibrary'.", $analysis[12]->getMessage());
-        $this->assertEquals("Install the mod 'llibrary' with version 1.7.9.", $analysis[12][0]->getMessage());
+        $this->assertEquals("The mod 'Forge Multipart CBE' is missing the required mods 'codechickenlib', 'forge'.", $analysis[12]->getMessage());
+        $this->assertEquals("Install the mod 'codechickenlib' with version 3.2.2.", $analysis[12][0]->getMessage());
+        $this->assertEquals("Install the mod 'forge' with version 14.23.5.2768.", $analysis[12][1]->getMessage());
+
+        $this->assertEquals("The mod 'Dragon Mounts' is missing the required mod 'llibrary'.", $analysis[13]->getMessage());
+        $this->assertEquals("Install the mod 'llibrary' with version 1.7.9.", $analysis[13][0]->getMessage());
 
     }
 }

--- a/test/tests/auto/Magma/MagmaPluginDependencyTest.php
+++ b/test/tests/auto/Magma/MagmaPluginDependencyTest.php
@@ -450,7 +450,32 @@ org.bukkit.plugin.UnknownDependencyException: ProtocolLib
                     [value:protected] => 1.8.8
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Information\Magma\MagmaVersionInformation Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [11:47:42] [Server thread/INFO]: Starting minecraft server version 1.8.8
+                                            [number:protected] => 1
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [11:47:42] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 16
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Information\Magma\MagmaVersionInformation Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -475,7 +500,7 @@ org.bukkit.plugin.UnknownDependencyException: ProtocolLib
                     [value:protected] => e2b9ab6
                 )
 
-            [2] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVersionInformation Object
+            [3] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVersionInformation Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -500,7 +525,7 @@ org.bukkit.plugin.UnknownDependencyException: ProtocolLib
                     [value:protected] => 14.23.5.2814
                 )
 
-            [3] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginDependencyProblem Object
+            [4] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -578,7 +603,7 @@ org.bukkit.plugin.UnknownDependencyException: ProtocolLib
                     [dependencyPluginName:protected] => Vault
                 )
 
-            [4] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginDependencyProblem Object
+            [5] => Aternos\Codex\Minecraft\Analysis\Problem\Bukkit\PluginDependencyProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -658,7 +683,7 @@ org.bukkit.plugin.UnknownDependencyException: ProtocolLib
 
         )
 
-    [iterator:protected] => 4
+    [iterator:protected] => 1
 )
 ';
         
@@ -667,17 +692,19 @@ org.bukkit.plugin.UnknownDependencyException: ProtocolLib
 
         $this->assertEquals("Minecraft version: 1.8.8", $analysis[0]->getMessage());
 
-        $this->assertEquals("Magma version: e2b9ab6", $analysis[1]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
 
-        $this->assertEquals("Forge version: 14.23.5.2814", $analysis[2]->getMessage());
+        $this->assertEquals("Magma version: e2b9ab6", $analysis[2]->getMessage());
 
-        $this->assertEquals("The plugin 'FactionsShop' is missing the required the plugin 'Vault'.", $analysis[3]->getMessage());
-        $this->assertEquals("Install the plugin 'Vault'.", $analysis[3][0]->getMessage());
-        $this->assertEquals("Delete the file 'plugins/FactionsShop.jar'.", $analysis[3][1]->getMessage());
+        $this->assertEquals("Forge version: 14.23.5.2814", $analysis[3]->getMessage());
 
-        $this->assertEquals("The plugin 'BasicTab' is missing the required the plugin 'ProtocolLib'.", $analysis[4]->getMessage());
-        $this->assertEquals("Install the plugin 'ProtocolLib'.", $analysis[4][0]->getMessage());
-        $this->assertEquals("Delete the file 'plugins/BasicTab.jar'.", $analysis[4][1]->getMessage());
+        $this->assertEquals("The plugin 'FactionsShop' is missing the required the plugin 'Vault'.", $analysis[4]->getMessage());
+        $this->assertEquals("Install the plugin 'Vault'.", $analysis[4][0]->getMessage());
+        $this->assertEquals("Delete the file 'plugins/FactionsShop.jar'.", $analysis[4][1]->getMessage());
+
+        $this->assertEquals("The plugin 'BasicTab' is missing the required the plugin 'ProtocolLib'.", $analysis[5]->getMessage());
+        $this->assertEquals("Install the plugin 'ProtocolLib'.", $analysis[5][0]->getMessage());
+        $this->assertEquals("Delete the file 'plugins/BasicTab.jar'.", $analysis[5][1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Magma/MagmaStart1122Test.php
+++ b/test/tests/auto/Magma/MagmaStart1122Test.php
@@ -5736,7 +5736,32 @@ class MagmaStart1122Test extends PHPUnit\Framework\TestCase
                     [value:protected] => 1.12.2
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVersionInformation Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [15:02:41] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer]: Starting minecraft server version 1.12.2
+                                            [number:protected] => 7
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [15:02:41] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer]:
+                        )
+
+                    [counter:protected] => 290
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Information\Forge\ForgeVersionInformation Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -5761,7 +5786,7 @@ class MagmaStart1122Test extends PHPUnit\Framework\TestCase
                     [value:protected] => 14.23.5.2847
                 )
 
-            [2] => Aternos\Codex\Minecraft\Analysis\Information\Magma\MagmaVersionInformation Object
+            [3] => Aternos\Codex\Minecraft\Analysis\Information\Magma\MagmaVersionInformation Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -5788,7 +5813,7 @@ class MagmaStart1122Test extends PHPUnit\Framework\TestCase
 
         )
 
-    [iterator:protected] => 2
+    [iterator:protected] => 1
 )
 ';
         
@@ -5797,9 +5822,11 @@ class MagmaStart1122Test extends PHPUnit\Framework\TestCase
 
         $this->assertEquals("Minecraft version: 1.12.2", $analysis[0]->getMessage());
 
-        $this->assertEquals("Forge version: 14.23.5.2847", $analysis[1]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
 
-        $this->assertEquals("Magma version: e2b9ab6", $analysis[2]->getMessage());
+        $this->assertEquals("Forge version: 14.23.5.2847", $analysis[2]->getMessage());
+
+        $this->assertEquals("Magma version: e2b9ab6", $analysis[3]->getMessage());
 
     }
 }

--- a/test/tests/auto/Mohist/Mohist1122Test.php
+++ b/test/tests/auto/Mohist/Mohist1122Test.php
@@ -7066,7 +7066,32 @@ class Mohist1122Test extends PHPUnit\Framework\TestCase
                     [value:protected] => 1.12.2
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Information\Mohist\MohistForgeVersionInformation Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [17:25:46] [Server thread/INFO] [Mohist]: Starting minecraft server version 1.12.2
+                                            [number:protected] => 27
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [17:25:46] [Server thread/INFO] [Mohist]:
+                        )
+
+                    [counter:protected] => 342
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Information\Mohist\MohistForgeVersionInformation Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -7091,7 +7116,7 @@ class Mohist1122Test extends PHPUnit\Framework\TestCase
                     [value:protected] => 14.23.5.2860
                 )
 
-            [2] => Aternos\Codex\Minecraft\Analysis\Information\Mohist\MohistVersionInformation Object
+            [3] => Aternos\Codex\Minecraft\Analysis\Information\Mohist\MohistVersionInformation Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -7118,7 +7143,7 @@ class Mohist1122Test extends PHPUnit\Framework\TestCase
 
         )
 
-    [iterator:protected] => 2
+    [iterator:protected] => 1
 )
 ';
         
@@ -7127,9 +7152,11 @@ class Mohist1122Test extends PHPUnit\Framework\TestCase
 
         $this->assertEquals("Minecraft version: 1.12.2", $analysis[0]->getMessage());
 
-        $this->assertEquals("Forge version: 14.23.5.2860", $analysis[1]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
 
-        $this->assertEquals("Mohist version: 304", $analysis[2]->getMessage());
+        $this->assertEquals("Forge version: 14.23.5.2860", $analysis[2]->getMessage());
+
+        $this->assertEquals("Mohist version: 304", $analysis[3]->getMessage());
 
     }
 }

--- a/test/tests/auto/Mohist/Mohist1165Test.php
+++ b/test/tests/auto/Mohist/Mohist1165Test.php
@@ -783,7 +783,32 @@ class Mohist1165Test extends PHPUnit\Framework\TestCase
                     [value:protected] => 36.2.23
                 )
 
-            [2] => Aternos\Codex\Minecraft\Analysis\Information\Mohist\MohistVersionInformation Object
+            [2] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [17:41:51] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer/]: Starting minecraft server version 1.16.5
+                                            [number:protected] => 13
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [17:41:51] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer/]:
+                        )
+
+                    [counter:protected] => 22
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [3] => Aternos\Codex\Minecraft\Analysis\Information\Mohist\MohistVersionInformation Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -821,7 +846,9 @@ class Mohist1165Test extends PHPUnit\Framework\TestCase
 
         $this->assertEquals("Forge version: 36.2.23", $analysis[1]->getMessage());
 
-        $this->assertEquals("Mohist version: 934", $analysis[2]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[2]->getMessage());
+
+        $this->assertEquals("Mohist version: 934", $analysis[3]->getMessage());
 
     }
 }

--- a/test/tests/auto/Vanilla/ClientSingleplayerTest.php
+++ b/test/tests/auto/Vanilla/ClientSingleplayerTest.php
@@ -1,0 +1,1173 @@
+<?php
+
+class ClientSingleplayerTest extends PHPUnit\Framework\TestCase
+{
+    public function testParseAndAnalyse(): void
+    {
+        date_default_timezone_set('UTC');
+        $logFile = new \Aternos\Codex\Log\File\PathLogFile(__DIR__ . "/../../../data/vanilla/client-singleplayer.log");
+        $detective = new \Aternos\Codex\Minecraft\Detective\Detective();
+        $detective->setLogFile($logFile);
+        $log = $detective->detect();
+        $log->parse();
+        $analysis = $log->analyse();
+        
+        $expectedLog = 'Aternos\Codex\Minecraft\Log\VanillaLog Object
+(
+    [entries:protected] => Array
+        (
+            [0] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:53:36] [Render thread/INFO]: Environment: authHost=\'https://authserver.mojang.com\', accountsHost=\'https://api.mojang.com\', sessionHost=\'https://sessionserver.mojang.com\', servicesHost=\'https://api.minecraftservices.com\', name=\'PROD\'
+                                    [number:protected] => 1
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:53:36] [Render thread/INFO]:
+                )
+
+            [1] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:53:37] [Render thread/INFO]: Setting user: JulianVennen
+                                    [number:protected] => 2
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:53:37] [Render thread/INFO]:
+                )
+
+            [2] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:53:38] [Render thread/WARN]: Invalid floating point value for option textBackgroundOpacity = 
+                                    [number:protected] => 3
+                                )
+
+                            [1] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => java.lang.NumberFormatException: empty String
+                                    [number:protected] => 4
+                                )
+
+                            [2] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => 	at jdk.internal.math.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:1842) ~[?:?]
+                                    [number:protected] => 5
+                                )
+
+                            [3] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => 	at jdk.internal.math.FloatingDecimal.parseDouble(FloatingDecimal.java:110) ~[?:?]
+                                    [number:protected] => 6
+                                )
+
+                            [4] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => 	at java.lang.Double.parseDouble(Double.java:651) ~[?:?]
+                                    [number:protected] => 7
+                                )
+
+                            [5] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => 	at dyv$2.a(SourceFile:429) [1.18.2.jar:?]
+                                    [number:protected] => 8
+                                )
+
+                            [6] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => 	at dyv.a(SourceFile:304) [1.18.2.jar:?]
+                                    [number:protected] => 9
+                                )
+
+                            [7] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => 	at dyv.a(SourceFile:387) [1.18.2.jar:?]
+                                    [number:protected] => 10
+                                )
+
+                            [8] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => 	at dyv.<init>(SourceFile:236) [1.18.2.jar:?]
+                                    [number:protected] => 11
+                                )
+
+                            [9] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => 	at dyr.<init>(SourceFile:454) [1.18.2.jar:?]
+                                    [number:protected] => 12
+                                )
+
+                            [10] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => 	at net.minecraft.client.main.Main.main(SourceFile:197) [1.18.2.jar:?]
+                                    [number:protected] => 13
+                                )
+
+                        )
+
+                    [level:protected] => WARN
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:53:38] [Render thread/WARN]:
+                )
+
+            [3] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:53:38] [Render thread/INFO]: Backend library: LWJGL version 3.2.2 build 10
+                                    [number:protected] => 14
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:53:38] [Render thread/INFO]:
+                )
+
+            [4] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:53:39] [Render thread/INFO]: Reloading ResourceManager: Default
+                                    [number:protected] => 15
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:53:39] [Render thread/INFO]:
+                )
+
+            [5] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:53:44] [Render thread/INFO]: OpenAL initialized on device SteelSeries Arctis 7 Game
+                                    [number:protected] => 16
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:53:44] [Render thread/INFO]:
+                )
+
+            [6] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:53:44] [Render thread/INFO]: Sound engine started
+                                    [number:protected] => 17
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:53:44] [Render thread/INFO]:
+                )
+
+            [7] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:53:45] [Render thread/INFO]: Created: 1024x1024x4 minecraft:textures/atlas/blocks.png-atlas
+                                    [number:protected] => 18
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:53:45] [Render thread/INFO]:
+                )
+
+            [8] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:53:45] [Render thread/INFO]: Created: 256x128x4 minecraft:textures/atlas/signs.png-atlas
+                                    [number:protected] => 19
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:53:45] [Render thread/INFO]:
+                )
+
+            [9] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:53:45] [Render thread/INFO]: Created: 1024x512x4 minecraft:textures/atlas/banner_patterns.png-atlas
+                                    [number:protected] => 20
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:53:45] [Render thread/INFO]:
+                )
+
+            [10] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:53:45] [Render thread/INFO]: Created: 1024x512x4 minecraft:textures/atlas/shield_patterns.png-atlas
+                                    [number:protected] => 21
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:53:45] [Render thread/INFO]:
+                )
+
+            [11] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:53:45] [Render thread/INFO]: Created: 256x256x4 minecraft:textures/atlas/chest.png-atlas
+                                    [number:protected] => 22
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:53:45] [Render thread/INFO]:
+                )
+
+            [12] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:53:45] [Render thread/INFO]: Created: 512x256x4 minecraft:textures/atlas/beds.png-atlas
+                                    [number:protected] => 23
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:53:45] [Render thread/INFO]:
+                )
+
+            [13] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:53:45] [Render thread/INFO]: Created: 512x256x4 minecraft:textures/atlas/shulker_boxes.png-atlas
+                                    [number:protected] => 24
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:53:45] [Render thread/INFO]:
+                )
+
+            [14] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:53:46] [Render thread/INFO]: Created: 256x256x0 minecraft:textures/atlas/particles.png-atlas
+                                    [number:protected] => 25
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:53:46] [Render thread/INFO]:
+                )
+
+            [15] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:53:47] [Render thread/INFO]: Created: 256x256x0 minecraft:textures/atlas/paintings.png-atlas
+                                    [number:protected] => 26
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:53:47] [Render thread/INFO]:
+                )
+
+            [16] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:53:47] [Render thread/INFO]: Created: 256x128x0 minecraft:textures/atlas/mob_effects.png-atlas
+                                    [number:protected] => 27
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:53:47] [Render thread/INFO]:
+                )
+
+            [17] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:05] [Render thread/WARN]: Ambiguity between arguments [teleport, location] and [teleport, destination] with inputs: [0.1 -0.5 .9, 0 0 0]
+                                    [number:protected] => 28
+                                )
+
+                        )
+
+                    [level:protected] => WARN
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:05] [Render thread/WARN]:
+                )
+
+            [18] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:05] [Render thread/WARN]: Ambiguity between arguments [teleport, location] and [teleport, targets] with inputs: [0.1 -0.5 .9, 0 0 0]
+                                    [number:protected] => 29
+                                )
+
+                        )
+
+                    [level:protected] => WARN
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:05] [Render thread/WARN]:
+                )
+
+            [19] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:05] [Render thread/WARN]: Ambiguity between arguments [teleport, destination] and [teleport, targets] with inputs: [Player, 0123, @e, dd12be42-52a9-4a91-a8a1-11c01849e498]
+                                    [number:protected] => 30
+                                )
+
+                        )
+
+                    [level:protected] => WARN
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:05] [Render thread/WARN]:
+                )
+
+            [20] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:05] [Render thread/WARN]: Ambiguity between arguments [teleport, targets] and [teleport, destination] with inputs: [Player, 0123, dd12be42-52a9-4a91-a8a1-11c01849e498]
+                                    [number:protected] => 31
+                                )
+
+                        )
+
+                    [level:protected] => WARN
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:05] [Render thread/WARN]:
+                )
+
+            [21] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:05] [Render thread/WARN]: Ambiguity between arguments [teleport, targets, location] and [teleport, targets, destination] with inputs: [0.1 -0.5 .9, 0 0 0]
+                                    [number:protected] => 32
+                                )
+
+                        )
+
+                    [level:protected] => WARN
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:05] [Render thread/WARN]:
+                )
+
+            [22] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:05] [Render thread/INFO]: Loaded 7 recipes
+                                    [number:protected] => 33
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:05] [Render thread/INFO]:
+                )
+
+            [23] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:05] [Render thread/INFO]: Loaded 1141 advancements
+                                    [number:protected] => 34
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:05] [Render thread/INFO]:
+                )
+
+            [24] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:06] [Render thread/INFO]: Environment: authHost=\'https://authserver.mojang.com\', accountsHost=\'https://api.mojang.com\', sessionHost=\'https://sessionserver.mojang.com\', servicesHost=\'https://api.minecraftservices.com\', name=\'PROD\'
+                                    [number:protected] => 35
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:06] [Render thread/INFO]:
+                )
+
+            [25] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:06] [Server thread/INFO]: Starting integrated minecraft server version 1.18.2
+                                    [number:protected] => 36
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:06] [Server thread/INFO]:
+                )
+
+            [26] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:06] [Server thread/INFO]: Generating keypair
+                                    [number:protected] => 37
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:06] [Server thread/INFO]:
+                )
+
+            [27] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:15] [Server thread/INFO]: Preparing start region for dimension minecraft:overworld
+                                    [number:protected] => 38
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:15] [Server thread/INFO]:
+                )
+
+            [28] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:16] [Render thread/INFO]: Preparing spawn area: 0%
+                                    [number:protected] => 39
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:16] [Render thread/INFO]:
+                )
+
+            [29] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:35] [Render thread/INFO]: Preparing spawn area: 96%
+                                    [number:protected] => 40
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:35] [Render thread/INFO]:
+                )
+
+            [30] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:36] [Render thread/INFO]: Time elapsed: 20866 ms
+                                    [number:protected] => 41
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:36] [Render thread/INFO]:
+                )
+
+            [31] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:36] [Server thread/INFO]: Changing view distance to 12, from 10
+                                    [number:protected] => 42
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:36] [Server thread/INFO]:
+                )
+
+            [32] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:36] [Server thread/INFO]: Changing simulation distance to 12, from 0
+                                    [number:protected] => 43
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:36] [Server thread/INFO]:
+                )
+
+            [33] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:36] [Server thread/INFO]: JulianVennen[local:E:b0f3fc68] logged in with entity id 100 at (-137.5, 76.0, 153.5)
+                                    [number:protected] => 44
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:36] [Server thread/INFO]:
+                )
+
+            [34] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:36] [Server thread/INFO]: JulianVennen joined the game
+                                    [number:protected] => 45
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:36] [Server thread/INFO]:
+                )
+
+            [35] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:36] [Render thread/INFO]: Loaded 0 advancements
+                                    [number:protected] => 46
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:36] [Render thread/INFO]:
+                )
+
+            [36] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:40] [Server thread/INFO]: Saving and pausing game...
+                                    [number:protected] => 47
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:40] [Server thread/INFO]:
+                )
+
+            [37] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:40] [Server thread/INFO]: Saving chunks for level \'ServerLevel[New World]\'/minecraft:overworld
+                                    [number:protected] => 48
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:40] [Server thread/INFO]:
+                )
+
+            [38] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:41] [Server thread/INFO]: Saving chunks for level \'ServerLevel[New World]\'/minecraft:the_nether
+                                    [number:protected] => 49
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:41] [Server thread/INFO]:
+                )
+
+            [39] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:41] [Server thread/INFO]: Saving chunks for level \'ServerLevel[New World]\'/minecraft:the_end
+                                    [number:protected] => 50
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:41] [Server thread/INFO]:
+                )
+
+            [40] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:41] [Server thread/INFO]: JulianVennen lost connection: Disconnected
+                                    [number:protected] => 51
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:41] [Server thread/INFO]:
+                )
+
+            [41] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:41] [Server thread/INFO]: JulianVennen left the game
+                                    [number:protected] => 52
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:41] [Server thread/INFO]:
+                )
+
+            [42] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:41] [Server thread/INFO]: Stopping singleplayer server as player logged out
+                                    [number:protected] => 53
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:41] [Server thread/INFO]:
+                )
+
+            [43] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:41] [Server thread/INFO]: Stopping server
+                                    [number:protected] => 54
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:41] [Server thread/INFO]:
+                )
+
+            [44] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:41] [Server thread/INFO]: Saving players
+                                    [number:protected] => 55
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:41] [Server thread/INFO]:
+                )
+
+            [45] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:41] [Server thread/INFO]: Saving worlds
+                                    [number:protected] => 56
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:41] [Server thread/INFO]:
+                )
+
+            [46] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:42] [Server thread/INFO]: Saving chunks for level \'ServerLevel[New World]\'/minecraft:overworld
+                                    [number:protected] => 57
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:42] [Server thread/INFO]:
+                )
+
+            [47] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:42] [Server thread/INFO]: Saving chunks for level \'ServerLevel[New World]\'/minecraft:the_nether
+                                    [number:protected] => 58
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:42] [Server thread/INFO]:
+                )
+
+            [48] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:42] [Server thread/INFO]: Saving chunks for level \'ServerLevel[New World]\'/minecraft:the_end
+                                    [number:protected] => 59
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:42] [Server thread/INFO]:
+                )
+
+            [49] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:42] [Server thread/INFO]: ThreadedAnvilChunkStorage (New World): All chunks are saved
+                                    [number:protected] => 60
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:42] [Server thread/INFO]:
+                )
+
+            [50] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:42] [Server thread/INFO]: ThreadedAnvilChunkStorage (DIM-1): All chunks are saved
+                                    [number:protected] => 61
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:42] [Server thread/INFO]:
+                )
+
+            [51] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:42] [Server thread/INFO]: ThreadedAnvilChunkStorage (DIM1): All chunks are saved
+                                    [number:protected] => 62
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:42] [Server thread/INFO]:
+                )
+
+            [52] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:42] [Server thread/INFO]: ThreadedAnvilChunkStorage: All dimensions are saved
+                                    [number:protected] => 63
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:42] [Server thread/INFO]:
+                )
+
+            [53] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:54:43] [Render thread/INFO]: Stopping!
+                                    [number:protected] => 64
+                                )
+
+                            [1] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => 
+                                    [number:protected] => 65
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:54:43] [Render thread/INFO]:
+                )
+
+        )
+
+    [iterator:protected] => 54
+    [logFile:protected] => Aternos\Codex\Log\File\PathLogFile Object
+        (
+            [content:protected] => [23:53:36] [Render thread/INFO]: Environment: authHost=\'https://authserver.mojang.com\', accountsHost=\'https://api.mojang.com\', sessionHost=\'https://sessionserver.mojang.com\', servicesHost=\'https://api.minecraftservices.com\', name=\'PROD\'
+[23:53:37] [Render thread/INFO]: Setting user: JulianVennen
+[23:53:38] [Render thread/WARN]: Invalid floating point value for option textBackgroundOpacity = 
+java.lang.NumberFormatException: empty String
+	at jdk.internal.math.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:1842) ~[?:?]
+	at jdk.internal.math.FloatingDecimal.parseDouble(FloatingDecimal.java:110) ~[?:?]
+	at java.lang.Double.parseDouble(Double.java:651) ~[?:?]
+	at dyv$2.a(SourceFile:429) [1.18.2.jar:?]
+	at dyv.a(SourceFile:304) [1.18.2.jar:?]
+	at dyv.a(SourceFile:387) [1.18.2.jar:?]
+	at dyv.<init>(SourceFile:236) [1.18.2.jar:?]
+	at dyr.<init>(SourceFile:454) [1.18.2.jar:?]
+	at net.minecraft.client.main.Main.main(SourceFile:197) [1.18.2.jar:?]
+[23:53:38] [Render thread/INFO]: Backend library: LWJGL version 3.2.2 build 10
+[23:53:39] [Render thread/INFO]: Reloading ResourceManager: Default
+[23:53:44] [Render thread/INFO]: OpenAL initialized on device SteelSeries Arctis 7 Game
+[23:53:44] [Render thread/INFO]: Sound engine started
+[23:53:45] [Render thread/INFO]: Created: 1024x1024x4 minecraft:textures/atlas/blocks.png-atlas
+[23:53:45] [Render thread/INFO]: Created: 256x128x4 minecraft:textures/atlas/signs.png-atlas
+[23:53:45] [Render thread/INFO]: Created: 1024x512x4 minecraft:textures/atlas/banner_patterns.png-atlas
+[23:53:45] [Render thread/INFO]: Created: 1024x512x4 minecraft:textures/atlas/shield_patterns.png-atlas
+[23:53:45] [Render thread/INFO]: Created: 256x256x4 minecraft:textures/atlas/chest.png-atlas
+[23:53:45] [Render thread/INFO]: Created: 512x256x4 minecraft:textures/atlas/beds.png-atlas
+[23:53:45] [Render thread/INFO]: Created: 512x256x4 minecraft:textures/atlas/shulker_boxes.png-atlas
+[23:53:46] [Render thread/INFO]: Created: 256x256x0 minecraft:textures/atlas/particles.png-atlas
+[23:53:47] [Render thread/INFO]: Created: 256x256x0 minecraft:textures/atlas/paintings.png-atlas
+[23:53:47] [Render thread/INFO]: Created: 256x128x0 minecraft:textures/atlas/mob_effects.png-atlas
+[23:54:05] [Render thread/WARN]: Ambiguity between arguments [teleport, location] and [teleport, destination] with inputs: [0.1 -0.5 .9, 0 0 0]
+[23:54:05] [Render thread/WARN]: Ambiguity between arguments [teleport, location] and [teleport, targets] with inputs: [0.1 -0.5 .9, 0 0 0]
+[23:54:05] [Render thread/WARN]: Ambiguity between arguments [teleport, destination] and [teleport, targets] with inputs: [Player, 0123, @e, dd12be42-52a9-4a91-a8a1-11c01849e498]
+[23:54:05] [Render thread/WARN]: Ambiguity between arguments [teleport, targets] and [teleport, destination] with inputs: [Player, 0123, dd12be42-52a9-4a91-a8a1-11c01849e498]
+[23:54:05] [Render thread/WARN]: Ambiguity between arguments [teleport, targets, location] and [teleport, targets, destination] with inputs: [0.1 -0.5 .9, 0 0 0]
+[23:54:05] [Render thread/INFO]: Loaded 7 recipes
+[23:54:05] [Render thread/INFO]: Loaded 1141 advancements
+[23:54:06] [Render thread/INFO]: Environment: authHost=\'https://authserver.mojang.com\', accountsHost=\'https://api.mojang.com\', sessionHost=\'https://sessionserver.mojang.com\', servicesHost=\'https://api.minecraftservices.com\', name=\'PROD\'
+[23:54:06] [Server thread/INFO]: Starting integrated minecraft server version 1.18.2
+[23:54:06] [Server thread/INFO]: Generating keypair
+[23:54:15] [Server thread/INFO]: Preparing start region for dimension minecraft:overworld
+[23:54:16] [Render thread/INFO]: Preparing spawn area: 0%
+[23:54:35] [Render thread/INFO]: Preparing spawn area: 96%
+[23:54:36] [Render thread/INFO]: Time elapsed: 20866 ms
+[23:54:36] [Server thread/INFO]: Changing view distance to 12, from 10
+[23:54:36] [Server thread/INFO]: Changing simulation distance to 12, from 0
+[23:54:36] [Server thread/INFO]: JulianVennen[local:E:b0f3fc68] logged in with entity id 100 at (-137.5, 76.0, 153.5)
+[23:54:36] [Server thread/INFO]: JulianVennen joined the game
+[23:54:36] [Render thread/INFO]: Loaded 0 advancements
+[23:54:40] [Server thread/INFO]: Saving and pausing game...
+[23:54:40] [Server thread/INFO]: Saving chunks for level \'ServerLevel[New World]\'/minecraft:overworld
+[23:54:41] [Server thread/INFO]: Saving chunks for level \'ServerLevel[New World]\'/minecraft:the_nether
+[23:54:41] [Server thread/INFO]: Saving chunks for level \'ServerLevel[New World]\'/minecraft:the_end
+[23:54:41] [Server thread/INFO]: JulianVennen lost connection: Disconnected
+[23:54:41] [Server thread/INFO]: JulianVennen left the game
+[23:54:41] [Server thread/INFO]: Stopping singleplayer server as player logged out
+[23:54:41] [Server thread/INFO]: Stopping server
+[23:54:41] [Server thread/INFO]: Saving players
+[23:54:41] [Server thread/INFO]: Saving worlds
+[23:54:42] [Server thread/INFO]: Saving chunks for level \'ServerLevel[New World]\'/minecraft:overworld
+[23:54:42] [Server thread/INFO]: Saving chunks for level \'ServerLevel[New World]\'/minecraft:the_nether
+[23:54:42] [Server thread/INFO]: Saving chunks for level \'ServerLevel[New World]\'/minecraft:the_end
+[23:54:42] [Server thread/INFO]: ThreadedAnvilChunkStorage (New World): All chunks are saved
+[23:54:42] [Server thread/INFO]: ThreadedAnvilChunkStorage (DIM-1): All chunks are saved
+[23:54:42] [Server thread/INFO]: ThreadedAnvilChunkStorage (DIM1): All chunks are saved
+[23:54:42] [Server thread/INFO]: ThreadedAnvilChunkStorage: All dimensions are saved
+[23:54:43] [Render thread/INFO]: Stopping!
+
+        )
+
+)
+';
+        
+        $expectedAnalysis = 'Aternos\Codex\Analysis\Analysis Object
+(
+    [insights:protected] => Array
+        (
+            [0] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [23:53:36] [Render thread/INFO]: Environment: authHost=\'https://authserver.mojang.com\', accountsHost=\'https://api.mojang.com\', sessionHost=\'https://sessionserver.mojang.com\', servicesHost=\'https://api.minecraftservices.com\', name=\'PROD\'
+                                            [number:protected] => 1
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [23:53:36] [Render thread/INFO]:
+                        )
+
+                    [counter:protected] => 54
+                    [label:protected] => Environment
+                    [value:protected] => Client
+                )
+
+        )
+
+    [iterator:protected] => 0
+)
+';
+        
+        $this->assertEquals($expectedLog, print_r($log, true));
+        $this->assertEquals($expectedAnalysis, print_r($analysis, true));
+
+        $this->assertEquals("Environment: Client", $analysis[0]->getMessage());
+
+    }
+}

--- a/test/tests/auto/Vanilla/ClientTest.php
+++ b/test/tests/auto/Vanilla/ClientTest.php
@@ -1,0 +1,489 @@
+<?php
+
+class ClientTest extends PHPUnit\Framework\TestCase
+{
+    public function testParseAndAnalyse(): void
+    {
+        date_default_timezone_set('UTC');
+        $logFile = new \Aternos\Codex\Log\File\PathLogFile(__DIR__ . "/../../../data/vanilla/client.log");
+        $detective = new \Aternos\Codex\Minecraft\Detective\Detective();
+        $detective->setLogFile($logFile);
+        $log = $detective->detect();
+        $log->parse();
+        $analysis = $log->analyse();
+        
+        $expectedLog = 'Aternos\Codex\Minecraft\Log\VanillaLog Object
+(
+    [entries:protected] => Array
+        (
+            [0] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:50:45] [Render thread/INFO]: Environment: authHost=\'https://authserver.mojang.com\', accountsHost=\'https://api.mojang.com\', sessionHost=\'https://sessionserver.mojang.com\', servicesHost=\'https://api.minecraftservices.com\', name=\'PROD\'
+                                    [number:protected] => 1
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:50:45] [Render thread/INFO]:
+                )
+
+            [1] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:50:45] [Render thread/INFO]: Setting user: JulianVennen
+                                    [number:protected] => 2
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:50:45] [Render thread/INFO]:
+                )
+
+            [2] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:50:46] [Render thread/WARN]: Invalid floating point value for option textBackgroundOpacity = 
+                                    [number:protected] => 3
+                                )
+
+                            [1] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => java.lang.NumberFormatException: empty String
+                                    [number:protected] => 4
+                                )
+
+                            [2] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => 	at jdk.internal.math.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:1842) ~[?:?]
+                                    [number:protected] => 5
+                                )
+
+                            [3] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => 	at jdk.internal.math.FloatingDecimal.parseDouble(FloatingDecimal.java:110) ~[?:?]
+                                    [number:protected] => 6
+                                )
+
+                            [4] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => 	at java.lang.Double.parseDouble(Double.java:651) ~[?:?]
+                                    [number:protected] => 7
+                                )
+
+                            [5] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => 	at dyv$2.a(SourceFile:429) [1.18.2.jar:?]
+                                    [number:protected] => 8
+                                )
+
+                            [6] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => 	at dyv.a(SourceFile:304) [1.18.2.jar:?]
+                                    [number:protected] => 9
+                                )
+
+                            [7] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => 	at dyv.a(SourceFile:387) [1.18.2.jar:?]
+                                    [number:protected] => 10
+                                )
+
+                            [8] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => 	at dyv.<init>(SourceFile:236) [1.18.2.jar:?]
+                                    [number:protected] => 11
+                                )
+
+                            [9] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => 	at dyr.<init>(SourceFile:454) [1.18.2.jar:?]
+                                    [number:protected] => 12
+                                )
+
+                            [10] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => 	at net.minecraft.client.main.Main.main(SourceFile:197) [1.18.2.jar:?]
+                                    [number:protected] => 13
+                                )
+
+                        )
+
+                    [level:protected] => WARN
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:50:46] [Render thread/WARN]:
+                )
+
+            [3] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:50:46] [Render thread/INFO]: Backend library: LWJGL version 3.2.2 build 10
+                                    [number:protected] => 14
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:50:46] [Render thread/INFO]:
+                )
+
+            [4] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:50:47] [Render thread/INFO]: Reloading ResourceManager: Default
+                                    [number:protected] => 15
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:50:47] [Render thread/INFO]:
+                )
+
+            [5] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:50:52] [Render thread/INFO]: OpenAL initialized on device SteelSeries Arctis 7 Game
+                                    [number:protected] => 16
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:50:52] [Render thread/INFO]:
+                )
+
+            [6] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:50:52] [Render thread/INFO]: Sound engine started
+                                    [number:protected] => 17
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:50:52] [Render thread/INFO]:
+                )
+
+            [7] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:50:53] [Render thread/INFO]: Created: 1024x1024x4 minecraft:textures/atlas/blocks.png-atlas
+                                    [number:protected] => 18
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:50:53] [Render thread/INFO]:
+                )
+
+            [8] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:50:53] [Render thread/INFO]: Created: 256x128x4 minecraft:textures/atlas/signs.png-atlas
+                                    [number:protected] => 19
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:50:53] [Render thread/INFO]:
+                )
+
+            [9] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:50:53] [Render thread/INFO]: Created: 1024x512x4 minecraft:textures/atlas/banner_patterns.png-atlas
+                                    [number:protected] => 20
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:50:53] [Render thread/INFO]:
+                )
+
+            [10] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:50:53] [Render thread/INFO]: Created: 1024x512x4 minecraft:textures/atlas/shield_patterns.png-atlas
+                                    [number:protected] => 21
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:50:53] [Render thread/INFO]:
+                )
+
+            [11] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:50:53] [Render thread/INFO]: Created: 256x256x4 minecraft:textures/atlas/chest.png-atlas
+                                    [number:protected] => 22
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:50:53] [Render thread/INFO]:
+                )
+
+            [12] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:50:53] [Render thread/INFO]: Created: 512x256x4 minecraft:textures/atlas/beds.png-atlas
+                                    [number:protected] => 23
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:50:53] [Render thread/INFO]:
+                )
+
+            [13] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:50:53] [Render thread/INFO]: Created: 512x256x4 minecraft:textures/atlas/shulker_boxes.png-atlas
+                                    [number:protected] => 24
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:50:53] [Render thread/INFO]:
+                )
+
+            [14] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:50:55] [Render thread/INFO]: Created: 256x256x0 minecraft:textures/atlas/particles.png-atlas
+                                    [number:protected] => 25
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:50:55] [Render thread/INFO]:
+                )
+
+            [15] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:50:55] [Render thread/INFO]: Created: 256x256x0 minecraft:textures/atlas/paintings.png-atlas
+                                    [number:protected] => 26
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:50:55] [Render thread/INFO]:
+                )
+
+            [16] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:50:55] [Render thread/INFO]: Created: 256x128x0 minecraft:textures/atlas/mob_effects.png-atlas
+                                    [number:protected] => 27
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:50:55] [Render thread/INFO]:
+                )
+
+            [17] => Aternos\Codex\Minecraft\Log\Entry Object
+                (
+                    [lines:protected] => Array
+                        (
+                            [0] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => [23:51:10] [Render thread/INFO]: Stopping!
+                                    [number:protected] => 28
+                                )
+
+                            [1] => Aternos\Codex\Log\Line Object
+                                (
+                                    [text:protected] => 
+                                    [number:protected] => 29
+                                )
+
+                        )
+
+                    [level:protected] => INFO
+                    [time:protected] => 
+                    [iterator:protected] => 0
+                    [prefix:protected] => [23:51:10] [Render thread/INFO]:
+                )
+
+        )
+
+    [iterator:protected] => 18
+    [logFile:protected] => Aternos\Codex\Log\File\PathLogFile Object
+        (
+            [content:protected] => [23:50:45] [Render thread/INFO]: Environment: authHost=\'https://authserver.mojang.com\', accountsHost=\'https://api.mojang.com\', sessionHost=\'https://sessionserver.mojang.com\', servicesHost=\'https://api.minecraftservices.com\', name=\'PROD\'
+[23:50:45] [Render thread/INFO]: Setting user: JulianVennen
+[23:50:46] [Render thread/WARN]: Invalid floating point value for option textBackgroundOpacity = 
+java.lang.NumberFormatException: empty String
+	at jdk.internal.math.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:1842) ~[?:?]
+	at jdk.internal.math.FloatingDecimal.parseDouble(FloatingDecimal.java:110) ~[?:?]
+	at java.lang.Double.parseDouble(Double.java:651) ~[?:?]
+	at dyv$2.a(SourceFile:429) [1.18.2.jar:?]
+	at dyv.a(SourceFile:304) [1.18.2.jar:?]
+	at dyv.a(SourceFile:387) [1.18.2.jar:?]
+	at dyv.<init>(SourceFile:236) [1.18.2.jar:?]
+	at dyr.<init>(SourceFile:454) [1.18.2.jar:?]
+	at net.minecraft.client.main.Main.main(SourceFile:197) [1.18.2.jar:?]
+[23:50:46] [Render thread/INFO]: Backend library: LWJGL version 3.2.2 build 10
+[23:50:47] [Render thread/INFO]: Reloading ResourceManager: Default
+[23:50:52] [Render thread/INFO]: OpenAL initialized on device SteelSeries Arctis 7 Game
+[23:50:52] [Render thread/INFO]: Sound engine started
+[23:50:53] [Render thread/INFO]: Created: 1024x1024x4 minecraft:textures/atlas/blocks.png-atlas
+[23:50:53] [Render thread/INFO]: Created: 256x128x4 minecraft:textures/atlas/signs.png-atlas
+[23:50:53] [Render thread/INFO]: Created: 1024x512x4 minecraft:textures/atlas/banner_patterns.png-atlas
+[23:50:53] [Render thread/INFO]: Created: 1024x512x4 minecraft:textures/atlas/shield_patterns.png-atlas
+[23:50:53] [Render thread/INFO]: Created: 256x256x4 minecraft:textures/atlas/chest.png-atlas
+[23:50:53] [Render thread/INFO]: Created: 512x256x4 minecraft:textures/atlas/beds.png-atlas
+[23:50:53] [Render thread/INFO]: Created: 512x256x4 minecraft:textures/atlas/shulker_boxes.png-atlas
+[23:50:55] [Render thread/INFO]: Created: 256x256x0 minecraft:textures/atlas/particles.png-atlas
+[23:50:55] [Render thread/INFO]: Created: 256x256x0 minecraft:textures/atlas/paintings.png-atlas
+[23:50:55] [Render thread/INFO]: Created: 256x128x0 minecraft:textures/atlas/mob_effects.png-atlas
+[23:51:10] [Render thread/INFO]: Stopping!
+
+        )
+
+)
+';
+        
+        $expectedAnalysis = 'Aternos\Codex\Analysis\Analysis Object
+(
+    [insights:protected] => Array
+        (
+            [0] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [23:50:45] [Render thread/INFO]: Environment: authHost=\'https://authserver.mojang.com\', accountsHost=\'https://api.mojang.com\', sessionHost=\'https://sessionserver.mojang.com\', servicesHost=\'https://api.minecraftservices.com\', name=\'PROD\'
+                                            [number:protected] => 1
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [23:50:45] [Render thread/INFO]:
+                        )
+
+                    [counter:protected] => 18
+                    [label:protected] => Environment
+                    [value:protected] => Client
+                )
+
+        )
+
+    [iterator:protected] => 0
+)
+';
+        
+        $this->assertEquals($expectedLog, print_r($log, true));
+        $this->assertEquals($expectedAnalysis, print_r($analysis, true));
+
+        $this->assertEquals("Environment: Client", $analysis[0]->getMessage());
+
+    }
+}

--- a/test/tests/auto/Vanilla/VanillaAquaticWorldOnOlderVersionTest.php
+++ b/test/tests/auto/Vanilla/VanillaAquaticWorldOnOlderVersionTest.php
@@ -355,7 +355,32 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
                     [value:protected] => 1.12.2
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Vanilla\AquaticWorldOnOlderVersionProblem Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [07:20:32] [Server thread/INFO]: Starting minecraft server version 1.12.2
+                                            [number:protected] => 1
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [07:20:32] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 11
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Vanilla\AquaticWorldOnOlderVersionProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -471,7 +496,7 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
 
         )
 
-    [iterator:protected] => 1
+    [iterator:protected] => 2
 )
 ';
         
@@ -480,9 +505,11 @@ at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
 
         $this->assertEquals("Minecraft version: 1.12.2", $analysis[0]->getMessage());
 
-        $this->assertEquals("The current world was created/loaded with Minecraft 1.13 or higher. The new format cannot be loaded in any older version.", $analysis[1]->getMessage());
-        $this->assertEquals("Generate a new world.", $analysis[1][0]->getMessage());
-        $this->assertEquals("Update the server software to 1.13 or newer.", $analysis[1][1]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
+
+        $this->assertEquals("The current world was created/loaded with Minecraft 1.13 or higher. The new format cannot be loaded in any older version.", $analysis[2]->getMessage());
+        $this->assertEquals("Generate a new world.", $analysis[2][0]->getMessage());
+        $this->assertEquals("Update the server software to 1.13 or newer.", $analysis[2][1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Vanilla/VanillaForgeTickingEntityTest.php
+++ b/test/tests/auto/Vanilla/VanillaForgeTickingEntityTest.php
@@ -915,7 +915,32 @@ at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:709) ~
                     [value:protected] => 1.10.2
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Vanilla\TickingBlockEntityProblem Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [16:20:04] [Server thread/INFO]: Starting minecraft server version 1.10.2
+                                            [number:protected] => 1
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [16:20:04] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 35
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Vanilla\TickingBlockEntityProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -1060,9 +1085,11 @@ at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:709) ~
 
         $this->assertEquals("Minecraft version: 1.10.2", $analysis[0]->getMessage());
 
-        $this->assertEquals("A block in the world is causing problems.", $analysis[1]->getMessage());
-        $this->assertEquals("Delete the file 'world'.", $analysis[1][0]->getMessage());
-        $this->assertEquals("Remove the block from the world, e.g. with MCEdit.", $analysis[1][1]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
+
+        $this->assertEquals("A block in the world is causing problems.", $analysis[2]->getMessage());
+        $this->assertEquals("Delete the file 'world'.", $analysis[2][0]->getMessage());
+        $this->assertEquals("Remove the block from the world, e.g. with MCEdit.", $analysis[2][1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Vanilla/VanillaMalformedEncodingTest.php
+++ b/test/tests/auto/Vanilla/VanillaMalformedEncodingTest.php
@@ -112,7 +112,86 @@ at net.minecraft.server.MinecraftServer.main(SourceFile:887) [minecraft_server.j
 (
     [insights:protected] => Array
         (
-            [0] => Aternos\Codex\Minecraft\Analysis\Problem\Vanilla\MalformedEncodingProblem Object
+            [0] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [21:28:50] [main/FATAL]: Failed to start the minecraft server
+                                            [number:protected] => 1
+                                        )
+
+                                    [1] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => java.lang.IllegalArgumentException: Malformed \uxxxx encoding.
+                                            [number:protected] => 2
+                                        )
+
+                                    [2] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => at java.util.Properties.loadConvert(Properties.java:574) ~[?:1.8.0_202]
+                                            [number:protected] => 3
+                                        )
+
+                                    [3] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => at java.util.Properties.load0(Properties.java:391) ~[?:1.8.0_202]
+                                            [number:protected] => 4
+                                        )
+
+                                    [4] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => at java.util.Properties.load(Properties.java:341) ~[?:1.8.0_202]
+                                            [number:protected] => 5
+                                        )
+
+                                    [5] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => at uk.b(SourceFile:55) ~[minecraft_server.jar:?]
+                                            [number:protected] => 6
+                                        )
+
+                                    [6] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => at uh.a(SourceFile:69) ~[minecraft_server.jar:?]
+                                            [number:protected] => 7
+                                        )
+
+                                    [7] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => at ui.&lt;init&gt;(SourceFile:12) ~[minecraft_server.jar:?]
+                                            [number:protected] => 8
+                                        )
+
+                                    [8] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => at net.minecraft.server.MinecraftServer.main(SourceFile:887) [minecraft_server.jar:?]
+                                            [number:protected] => 9
+                                        )
+
+                                    [9] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => 
+                                            [number:protected] => 10
+                                        )
+
+                                )
+
+                            [level:protected] => FATAL
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [21:28:50] [main/FATAL]:
+                        )
+
+                    [counter:protected] => 1
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Vanilla\MalformedEncodingProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -200,15 +279,17 @@ at net.minecraft.server.MinecraftServer.main(SourceFile:887) [minecraft_server.j
 
         )
 
-    [iterator:protected] => 0
+    [iterator:protected] => 1
 )
 ';
         
         $this->assertEquals($expectedLog, print_r($log, true));
         $this->assertEquals($expectedAnalysis, print_r($analysis, true));
 
-        $this->assertEquals("Something (probably the MOTD) contains malformed formatting codes.", $analysis[0]->getMessage());
-        $this->assertEquals("Change the server MOTD.", $analysis[0][0]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[0]->getMessage());
+
+        $this->assertEquals("Something (probably the MOTD) contains malformed formatting codes.", $analysis[1]->getMessage());
+        $this->assertEquals("Change the server MOTD.", $analysis[1][0]->getMessage());
 
     }
 }

--- a/test/tests/auto/Vanilla/VanillaOldPlayerDirectoryTest.php
+++ b/test/tests/auto/Vanilla/VanillaOldPlayerDirectoryTest.php
@@ -264,7 +264,32 @@ class VanillaOldPlayerDirectoryTest extends PHPUnit\Framework\TestCase
                     [value:protected] => 1.12.2
                 )
 
-            [1] => Aternos\Codex\Minecraft\Analysis\Problem\Vanilla\OldPlayerDirectoryProblem Object
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [10:03:34] [Server thread/INFO]: Starting minecraft server version 1.12.2
+                                            [number:protected] => 1
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [10:03:34] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 10
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
+            [2] => Aternos\Codex\Minecraft\Analysis\Problem\Vanilla\OldPlayerDirectoryProblem Object
                 (
                     [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
                         (
@@ -309,8 +334,10 @@ class VanillaOldPlayerDirectoryTest extends PHPUnit\Framework\TestCase
 
         $this->assertEquals("Minecraft version: 1.12.2", $analysis[0]->getMessage());
 
-        $this->assertEquals("The server has detected an old player directory in the world save.", $analysis[1]->getMessage());
-        $this->assertEquals("Delete the file 'world/players'.", $analysis[1][0]->getMessage());
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
+
+        $this->assertEquals("The server has detected an old player directory in the world save.", $analysis[2]->getMessage());
+        $this->assertEquals("Delete the file 'world/players'.", $analysis[2][0]->getMessage());
 
     }
 }

--- a/test/tests/auto/Vanilla/VanillaSnapshot19w34aTest.php
+++ b/test/tests/auto/Vanilla/VanillaSnapshot19w34aTest.php
@@ -150,9 +150,34 @@ class VanillaSnapshot19w34aTest extends PHPUnit\Framework\TestCase
                     [value:protected] => 19w34a
                 )
 
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [18:19:38] [Server thread/INFO]: Starting minecraft server version 19w34a
+                                            [number:protected] => 1
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [18:19:38] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 5
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
         )
 
-    [iterator:protected] => 0
+    [iterator:protected] => 1
 )
 ';
         
@@ -160,6 +185,8 @@ class VanillaSnapshot19w34aTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($expectedAnalysis, print_r($analysis, true));
 
         $this->assertEquals("Minecraft version: 19w34a", $analysis[0]->getMessage());
+
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Vanilla/VanillaSnapshot21w05bTest.php
+++ b/test/tests/auto/Vanilla/VanillaSnapshot21w05bTest.php
@@ -530,9 +530,34 @@ class VanillaSnapshot21w05bTest extends PHPUnit\Framework\TestCase
                     [value:protected] => 21w05b
                 )
 
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [12:35:38] [Server thread/INFO]: Starting minecraft server version 21w05b
+                                            [number:protected] => 10
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [12:35:38] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 15
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
         )
 
-    [iterator:protected] => 0
+    [iterator:protected] => 1
 )
 ';
         
@@ -540,6 +565,8 @@ class VanillaSnapshot21w05bTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($expectedAnalysis, print_r($analysis, true));
 
         $this->assertEquals("Minecraft version: 21w05b", $analysis[0]->getMessage());
+
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
 
     }
 }

--- a/test/tests/auto/Vanilla/VanillaStart1132Test.php
+++ b/test/tests/auto/Vanilla/VanillaStart1132Test.php
@@ -2107,9 +2107,34 @@ class VanillaStart1132Test extends PHPUnit\Framework\TestCase
                     [value:protected] => 1.13.2
                 )
 
+            [1] => Aternos\Codex\Minecraft\Analysis\Information\Vanilla\EnvironmentInformation Object
+                (
+                    [entry:protected] => Aternos\Codex\Minecraft\Log\Entry Object
+                        (
+                            [lines:protected] => Array
+                                (
+                                    [0] => Aternos\Codex\Log\Line Object
+                                        (
+                                            [text:protected] => [18:25:33] [Server thread/INFO]: Starting minecraft server version 1.13.2
+                                            [number:protected] => 8
+                                        )
+
+                                )
+
+                            [level:protected] => INFO
+                            [time:protected] => 
+                            [iterator:protected] => 0
+                            [prefix:protected] => [18:25:33] [Server thread/INFO]:
+                        )
+
+                    [counter:protected] => 100
+                    [label:protected] => Environment
+                    [value:protected] => Server
+                )
+
         )
 
-    [iterator:protected] => 0
+    [iterator:protected] => 1
 )
 ';
         
@@ -2117,6 +2142,8 @@ class VanillaStart1132Test extends PHPUnit\Framework\TestCase
         $this->assertEquals($expectedAnalysis, print_r($analysis, true));
 
         $this->assertEquals("Minecraft version: 1.13.2", $analysis[0]->getMessage());
+
+        $this->assertEquals("Environment: Server", $analysis[1]->getMessage());
 
     }
 }


### PR DESCRIPTION
I always return true for the isEqual checks to prevent both insights existing in singleplayer.
Since the client start up logs under the Render thread, it should always be detected correctly. 
If you have a different idea on how to do that, I'd be happy to implement it.