### PR TITLE
Add multiline flag to every detector regex that asserts a start position

### DIFF
--- a/src/Log/Minecraft/Vanilla/Bukkit/Paper/PaperCrashReportLog.php
+++ b/src/Log/Minecraft/Vanilla/Bukkit/Paper/PaperCrashReportLog.php
@@ -21,6 +21,6 @@ class PaperCrashReportLog extends PaperLog implements CrashReportLogTypeInterfac
      */
     public static function getDetectors(): array
     {
-        return [(new SinglePatternDetector())->setPattern("/^---- Minecraft Crash Report ----(\n.*)*\n\s+Running: Paper version git-Paper/")];
+        return [(new SinglePatternDetector())->setPattern("/^---- Minecraft Crash Report ----(\n.*)*\n\s+Running: Paper version git-Paper/m")];
     }
 }

--- a/src/Log/Minecraft/Vanilla/Bukkit/Purpur/PurpurCrashReportLog.php
+++ b/src/Log/Minecraft/Vanilla/Bukkit/Purpur/PurpurCrashReportLog.php
@@ -21,6 +21,6 @@ class PurpurCrashReportLog extends PurpurLog implements CrashReportLogTypeInterf
      */
     public static function getDetectors(): array
     {
-        return [(new SinglePatternDetector())->setPattern("/^---- Minecraft Crash Report ----(\n.*)*\n\s+Running: Purpur version git-Purpur/")];
+        return [(new SinglePatternDetector())->setPattern("/^---- Minecraft Crash Report ----(\n.*)*\n\s+Running: Purpur version git-Purpur/m")];
     }
 }

--- a/src/Log/Minecraft/Vanilla/Fabric/FabricClientLog.php
+++ b/src/Log/Minecraft/Vanilla/Fabric/FabricClientLog.php
@@ -19,7 +19,7 @@ class FabricClientLog extends FabricLog implements ClientLogTypeInterface
     public static function getDetectors(): array
     {
         return [
-            (new SinglePatternDetector())->setPattern('/\[[\d:]+\] \[main\/INFO\]: Loading Minecraft [^ \n]+ with Fabric Loader [^ \n]+(\n.*)*\n\[[\d:]+\] \[Render thread\/INFO\]: Setting user: \w+/'),
+            (new SinglePatternDetector())->setPattern('/^\[[\d:]+\] \[main\/INFO\]: Loading Minecraft [^ \n]+ with Fabric Loader [^ \n]+(\n.*)*\n\[[\d:]+\] \[Render thread\/INFO\]: Setting user: \w+/m'),
         ];
     }
 }

--- a/src/Log/Minecraft/Vanilla/Fabric/FabricCrashReportLog.php
+++ b/src/Log/Minecraft/Vanilla/Fabric/FabricCrashReportLog.php
@@ -23,7 +23,7 @@ class FabricCrashReportLog extends FabricLog implements CrashReportLogTypeInterf
      */
     public static function getDetectors(): array
     {
-        return [(new SinglePatternDetector())->setPattern("/^---- Minecraft Crash Report ----(\n.*)*\n\t(?:Known )?server brands?: fabric/i")];
+        return [(new SinglePatternDetector())->setPattern("/^---- Minecraft Crash Report ----(\n.*)*\n\t(?:Known )?server brands?: fabric/im")];
     }
 
     /**

--- a/src/Log/Minecraft/Vanilla/Fabric/FabricLog.php
+++ b/src/Log/Minecraft/Vanilla/Fabric/FabricLog.php
@@ -22,7 +22,7 @@ abstract class FabricLog extends VanillaLog
     public static function getDetectors(): array
     {
         return array_merge(parent::getDetectors(), [
-            (new SinglePatternDetector())->setPattern('/^' . static::$prefixPattern . 'Loading Minecraft '. VanillaVersionInformation::getVersionPattern() . ' with Fabric Loader/'),
+            (new SinglePatternDetector())->setPattern('/^' . static::$prefixPattern . 'Loading Minecraft '. VanillaVersionInformation::getVersionPattern() . ' with Fabric Loader/m'),
             (new SinglePatternDetector())->setPattern('/^' . static::$prefixPattern . '\[FabricLoader\] Loading \d+ mods:/m'),
             (new SinglePatternDetector())->setPattern('/^' . static::$prefixPattern . 'A critical error occurred\nnet.fabricmc.loader/m'),
             (new SinglePatternDetector())->setPattern('/^' . static::$prefixPattern . 'Found new data pack Fabric Mods, loading it automatically$/m'),

--- a/src/Log/Minecraft/Vanilla/Forge/Arclight/ArclightCrashReportLog.php
+++ b/src/Log/Minecraft/Vanilla/Forge/Arclight/ArclightCrashReportLog.php
@@ -21,6 +21,6 @@ class ArclightCrashReportLog extends ArclightLog implements CrashReportLogTypeIn
      */
     public static function getDetectors(): array
     {
-        return [(new SinglePatternDetector())->setPattern("/^---- Minecraft Crash Report ----(\n.*)*\n\tKnown server brands:( [a-zA-Z])* arclight/")];
+        return [(new SinglePatternDetector())->setPattern("/^---- Minecraft Crash Report ----(\n.*)*\n\tKnown server brands:( [a-zA-Z])* arclight/m")];
     }
 }

--- a/src/Log/Minecraft/Vanilla/Forge/ForgeCrashReportLog.php
+++ b/src/Log/Minecraft/Vanilla/Forge/ForgeCrashReportLog.php
@@ -23,7 +23,7 @@ class ForgeCrashReportLog extends ForgeLog implements CrashReportLogTypeInterfac
      */
     public static function getDetectors(): array
     {
-        return [(new SinglePatternDetector())->setPattern("/^---- Minecraft Crash Report ----(\n.*)*\n\tFML:/")];
+        return [(new SinglePatternDetector())->setPattern("/^---- Minecraft Crash Report ----(\n.*)*\n\tFML:/m")];
     }
 
 

--- a/src/Log/Minecraft/Vanilla/Quilt/QuiltLog.php
+++ b/src/Log/Minecraft/Vanilla/Quilt/QuiltLog.php
@@ -21,7 +21,7 @@ abstract class QuiltLog extends VanillaLog
     public static function getDetectors(): array
     {
         return array_merge(parent::getDetectors(), [
-            (new SinglePatternDetector())->setPattern('/^' . static::$prefixPattern . 'Loading Minecraft '. VanillaVersionInformation::getVersionPattern() . ' with Quilt Loader/')
+            (new SinglePatternDetector())->setPattern('/^' . static::$prefixPattern . 'Loading Minecraft '. VanillaVersionInformation::getVersionPattern() . ' with Quilt Loader/m')
         ]);
     }
 


### PR DESCRIPTION
In some scenarios like Prism Launcher logs, there might be additional content before the actual log beginning, so we shouldn't depend on messages being the first line in a log.