### PR TITLE
Detect neoforge early (Fixes #70)

### DIFF
--- a/src/Analysis/Information/Forge/ForgeJavaVersionInformation.php
+++ b/src/Analysis/Information/Forge/ForgeJavaVersionInformation.php
@@ -25,7 +25,7 @@ class ForgeJavaVersionInformation extends ForgeInformation
      */
     public static function getPatterns(): array
     {
-        return ['/\[cpw\.mods\.modlauncher\.Launcher\/MODLAUNCHER\]: ModLauncher(?: [\w\.+]+)? starting: java version ([0-9\._]+) by Oracle Corporation/'];
+        return ['/\[[^\]]+\]: ModLauncher(?: [\w\.+]+)? starting: java version ([0-9\._]+) by/'];
     }
 
 }

--- a/src/Analysis/Information/NeoForge/NeoForgeJavaVersionInformation.php
+++ b/src/Analysis/Information/NeoForge/NeoForgeJavaVersionInformation.php
@@ -16,6 +16,6 @@ class NeoForgeJavaVersionInformation extends NeoForgeInformation
      */
     public static function getPatterns(): array
     {
-        return ['/\[cpw\.mods\.modlauncher\.Launcher\/MODLAUNCHER\]: ModLauncher(?: [\w\.+]+)? starting: java version ([0-9\._]+) by Oracle Corporation/'];
+        return ['/\[[^\]]+\]: ModLauncher(?: [\w\.+]+)? starting: java version ([0-9\._]+) by/'];
     }
 }

--- a/src/Log/Minecraft/Vanilla/NeoForge/NeoForgeLog.php
+++ b/src/Log/Minecraft/Vanilla/NeoForge/NeoForgeLog.php
@@ -20,7 +20,8 @@ abstract class NeoForgeLog extends VanillaLog
     public static function getDetectors(): array
     {
         return array_merge(parent::getDetectors(), [
-            (new SinglePatternDetector())->setPattern('/NeoForge mod loading/')
+            (new SinglePatternDetector())->setPattern('/NeoForge mod loading/'),
+            (new SinglePatternDetector())->setPattern('/^\[[^\]]+\] \[main\/INFO\]( \[[^\]]+\])?: ModLauncher running: .*--fml.neoForgeVersion/')
         ]);
     }
 

--- a/test/data/Vanilla/Forge/Arclight/arclight-1192.json
+++ b/test/data/Vanilla/Forge/Arclight/arclight-1192.json
@@ -2893,6 +2893,23 @@
                 "value": "43.1.55"
             },
             {
+                "message": "Java version: 17.0.4.1",
+                "counter": 1,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[05Dec2022 05:20:00.558] [main\/INFO] [cpw.mods.modlauncher.Launcher\/MODLAUNCHER]:",
+                    "lines": [
+                        {
+                            "number": 14,
+                            "content": "[05Dec2022 05:20:00.558] [main\/INFO] [cpw.mods.modlauncher.Launcher\/MODLAUNCHER]: ModLauncher 10.0.8+10.0.8+main.0ef7e830 starting: java version 17.0.4.1 by Eclipse Adoptium; OS Linux arch amd64 version 5.4.0-91-generic"
+                        }
+                    ]
+                },
+                "label": "Java version",
+                "value": "17.0.4.1"
+            },
+            {
                 "message": "Arclight version: b8adaaba",
                 "counter": 1,
                 "entry": {

--- a/test/data/Vanilla/Forge/forge-client-1-19-2.json
+++ b/test/data/Vanilla/Forge/forge-client-1-19-2.json
@@ -603,6 +603,23 @@
                 },
                 "label": "Forge version",
                 "value": "43.0.11"
+            },
+            {
+                "message": "Java version: 18.0.2",
+                "counter": 1,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[16Aug2022 16:05:10.354] [main\/INFO] [cpw.mods.modlauncher.Launcher\/MODLAUNCHER]:",
+                    "lines": [
+                        {
+                            "number": 2,
+                            "content": "[16Aug2022 16:05:10.354] [main\/INFO] [cpw.mods.modlauncher.Launcher\/MODLAUNCHER]: ModLauncher 10.0.8+10.0.8+main.0ef7e830 starting: java version 18.0.2 by N\/A; OS Linux arch amd64 version 5.15.59-1-MANJARO"
+                        }
+                    ]
+                },
+                "label": "Java version",
+                "value": "18.0.2"
             }
         ]
     }

--- a/test/data/Vanilla/Forge/forge-language-provider-version-above.json
+++ b/test/data/Vanilla/Forge/forge-language-provider-version-above.json
@@ -817,6 +817,23 @@
                 },
                 "label": "Forge version",
                 "value": "47.2.0"
+            },
+            {
+                "message": "Java version: 17.0.10",
+                "counter": 1,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[05Apr2024 11:10:31.923] [main\/INFO] [cpw.mods.modlauncher.Launcher\/MODLAUNCHER]:",
+                    "lines": [
+                        {
+                            "number": 2,
+                            "content": "[05Apr2024 11:10:31.923] [main\/INFO] [cpw.mods.modlauncher.Launcher\/MODLAUNCHER]: ModLauncher 10.0.9+10.0.9+main.dcd20f30 starting: java version 17.0.10 by Eclipse Adoptium; OS Linux arch amd64 version 5.15.0-88-generic"
+                        }
+                    ]
+                },
+                "label": "Java version",
+                "value": "17.0.10"
             }
         ]
     }

--- a/test/data/Vanilla/Forge/forge-language-provider-version-between.json
+++ b/test/data/Vanilla/Forge/forge-language-provider-version-between.json
@@ -795,6 +795,23 @@
                 },
                 "label": "Forge version",
                 "value": "47.2.0"
+            },
+            {
+                "message": "Java version: 17.0.10",
+                "counter": 1,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[05Apr2024 11:46:47.928] [main\/INFO] [cpw.mods.modlauncher.Launcher\/MODLAUNCHER]:",
+                    "lines": [
+                        {
+                            "number": 2,
+                            "content": "[05Apr2024 11:46:47.928] [main\/INFO] [cpw.mods.modlauncher.Launcher\/MODLAUNCHER]: ModLauncher 10.0.9+10.0.9+main.dcd20f30 starting: java version 17.0.10 by Eclipse Adoptium; OS Linux arch amd64 version 5.15.0-94-generic"
+                        }
+                    ]
+                },
+                "label": "Java version",
+                "value": "17.0.10"
             }
         ]
     }

--- a/test/data/Vanilla/Forge/forge-multiple-modules-export.json
+++ b/test/data/Vanilla/Forge/forge-multiple-modules-export.json
@@ -233,6 +233,23 @@
                 },
                 "label": "Forge version",
                 "value": "39.1.0"
+            },
+            {
+                "message": "Java version: 17.0.2",
+                "counter": 1,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[20:14:29] [main\/INFO] [cp.mo.mo.Launcher\/MODLAUNCHER]:",
+                    "lines": [
+                        {
+                            "number": 2,
+                            "content": "[20:14:29] [main\/INFO] [cp.mo.mo.Launcher\/MODLAUNCHER]: ModLauncher 9.1.0+9.1.0+main.6690ee51 starting: java version 17.0.2 by Oracle Corporation"
+                        }
+                    ]
+                },
+                "label": "Java version",
+                "value": "17.0.2"
             }
         ]
     }

--- a/test/data/Vanilla/Forge/forge-polymc-1-19-2.json
+++ b/test/data/Vanilla/Forge/forge-polymc-1-19-2.json
@@ -1068,6 +1068,23 @@
                 },
                 "label": "Forge version",
                 "value": "43.0.11"
+            },
+            {
+                "message": "Java version: 18.0.2",
+                "counter": 1,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[14:52:17] [main\/INFO] [cp.mo.mo.Launcher\/MODLAUNCHER]:",
+                    "lines": [
+                        {
+                            "number": 151,
+                            "content": "[14:52:17] [main\/INFO] [cp.mo.mo.Launcher\/MODLAUNCHER]: ModLauncher 10.0.8+10.0.8+main.0ef7e830 starting: java version 18.0.2 by N\/A; OS Linux arch amd64 version 5.15.60-1-MANJARO"
+                        }
+                    ]
+                },
+                "label": "Java version",
+                "value": "18.0.2"
             }
         ]
     }

--- a/test/data/Vanilla/NeoForge/neoforge-1-20-4-client.json
+++ b/test/data/Vanilla/NeoForge/neoforge-1-20-4-client.json
@@ -649,6 +649,23 @@
                 "value": "20.4.155-beta"
             },
             {
+                "message": "Java version: 17.0.3",
+                "counter": 1,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[09Feb2024 11:42:04.592] [main\/INFO] [cpw.mods.modlauncher.Launcher\/MODLAUNCHER]:",
+                    "lines": [
+                        {
+                            "number": 2,
+                            "content": "[09Feb2024 11:42:04.592] [main\/INFO] [cpw.mods.modlauncher.Launcher\/MODLAUNCHER]: ModLauncher 10.0.9+10.0.9+main.dcd20f30 starting: java version 17.0.3 by Microsoft; OS Linux arch amd64 version 6.7.3-200.fc39.x86_64"
+                        }
+                    ]
+                },
+                "label": "Java version",
+                "value": "17.0.3"
+            },
+            {
                 "message": "Minecraft version: 20.4.155-beta",
                 "counter": 1,
                 "entry": {

--- a/test/data/Vanilla/NeoForge/neoforge-1-20-4-server-early.json
+++ b/test/data/Vanilla/NeoForge/neoforge-1-20-4-server-early.json
@@ -1,0 +1,142 @@
+{
+    "id": "neoforge\/server",
+    "name": "NeoForge",
+    "type": "Server Log",
+    "version": "1.20.4",
+    "title": "NeoForge 1.20.4 Server Log",
+    "entries": [
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[12:20:31] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 1,
+                    "content": "[12:20:31] [main\/INFO]: ModLauncher running: args [--launchTarget, forgeserver, --fml.neoForgeVersion, 20.4.155-beta, --fml.fmlVersion, 2.0.11, --fml.mcVersion, 1.20.4, --fml.neoFormVersion, 20231207.154220, nogui]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[12:20:31] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 2,
+                    "content": "[12:20:31] [main\/INFO]: ModLauncher 10.0.9+10.0.9+main.dcd20f30 starting: java version 17.0.10 by Eclipse Adoptium; OS Linux arch amd64 version 5.15.0-88-generic"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[12:20:31] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 3,
+                    "content": "[12:20:31] [main\/INFO]: ImmediateWindowProvider not loading because launch target is forgeserver"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[12:20:31] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 4,
+                    "content": "[12:20:31] [main\/INFO]: SpongePowered MIXIN Subsystem Version=0.8.5 Source=union:\/server\/libraries\/org\/spongepowered\/mixin\/0.8.5\/mixin-0.8.5.jar%2379!\/ Service=ModLauncher Env=SERVER"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[12:20:32] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 5,
+                    "content": "[12:20:32] [main\/INFO]: Found mod file \"server-1.20.4-20231207.154220-srg.jar\" of type MOD with provider net.neoforged.fml.loading.moddiscovery.MinecraftLocator@515ebef3"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[12:20:32] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 6,
+                    "content": "[12:20:32] [main\/INFO]: Found mod file \"neoforge-20.4.155-beta-universal.jar\" of type MOD with provider net.neoforged.fml.loading.moddiscovery.MinecraftLocator@515ebef3"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[12:20:32] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 7,
+                    "content": "[12:20:32] [main\/INFO]: Found 1 dependencies adding them to mods collection"
+                }
+            ]
+        }
+    ],
+    "analysis": {
+        "problems": [],
+        "information": [
+            {
+                "message": "Minecraft version: 1.20.4",
+                "counter": 1,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[12:20:31] [main\/INFO]:",
+                    "lines": [
+                        {
+                            "number": 1,
+                            "content": "[12:20:31] [main\/INFO]: ModLauncher running: args [--launchTarget, forgeserver, --fml.neoForgeVersion, 20.4.155-beta, --fml.fmlVersion, 2.0.11, --fml.mcVersion, 1.20.4, --fml.neoFormVersion, 20231207.154220, nogui]"
+                        }
+                    ]
+                },
+                "label": "Minecraft version",
+                "value": "1.20.4"
+            },
+            {
+                "message": "NeoForge version: 20.4.155-beta",
+                "counter": 1,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[12:20:31] [main\/INFO]:",
+                    "lines": [
+                        {
+                            "number": 1,
+                            "content": "[12:20:31] [main\/INFO]: ModLauncher running: args [--launchTarget, forgeserver, --fml.neoForgeVersion, 20.4.155-beta, --fml.fmlVersion, 2.0.11, --fml.mcVersion, 1.20.4, --fml.neoFormVersion, 20231207.154220, nogui]"
+                        }
+                    ]
+                },
+                "label": "NeoForge version",
+                "value": "20.4.155-beta"
+            },
+            {
+                "message": "Java version: 17.0.10",
+                "counter": 1,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[12:20:31] [main\/INFO]:",
+                    "lines": [
+                        {
+                            "number": 2,
+                            "content": "[12:20:31] [main\/INFO]: ModLauncher 10.0.9+10.0.9+main.dcd20f30 starting: java version 17.0.10 by Eclipse Adoptium; OS Linux arch amd64 version 5.15.0-88-generic"
+                        }
+                    ]
+                },
+                "label": "Java version",
+                "value": "17.0.10"
+            }
+        ]
+    }
+}

--- a/test/data/Vanilla/NeoForge/neoforge-1-20-4-server-early.log
+++ b/test/data/Vanilla/NeoForge/neoforge-1-20-4-server-early.log
@@ -1,0 +1,7 @@
+[12:20:31] [main/INFO]: ModLauncher running: args [--launchTarget, forgeserver, --fml.neoForgeVersion, 20.4.155-beta, --fml.fmlVersion, 2.0.11, --fml.mcVersion, 1.20.4, --fml.neoFormVersion, 20231207.154220, nogui]
+[12:20:31] [main/INFO]: ModLauncher 10.0.9+10.0.9+main.dcd20f30 starting: java version 17.0.10 by Eclipse Adoptium; OS Linux arch amd64 version 5.15.0-88-generic
+[12:20:31] [main/INFO]: ImmediateWindowProvider not loading because launch target is forgeserver
+[12:20:31] [main/INFO]: SpongePowered MIXIN Subsystem Version=0.8.5 Source=union:/server/libraries/org/spongepowered/mixin/0.8.5/mixin-0.8.5.jar%2379!/ Service=ModLauncher Env=SERVER
+[12:20:32] [main/INFO]: Found mod file "server-1.20.4-20231207.154220-srg.jar" of type MOD with provider net.neoforged.fml.loading.moddiscovery.MinecraftLocator@515ebef3
+[12:20:32] [main/INFO]: Found mod file "neoforge-20.4.155-beta-universal.jar" of type MOD with provider net.neoforged.fml.loading.moddiscovery.MinecraftLocator@515ebef3
+[12:20:32] [main/INFO]: Found 1 dependencies adding them to mods collection

--- a/test/data/Vanilla/NeoForge/neoforge-1-20-4-server.json
+++ b/test/data/Vanilla/NeoForge/neoforge-1-20-4-server.json
@@ -1375,6 +1375,23 @@
                 "value": "20.4.155-beta"
             },
             {
+                "message": "Java version: 17.0.10",
+                "counter": 1,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[12:20:31] [main\/INFO]:",
+                    "lines": [
+                        {
+                            "number": 2,
+                            "content": "[12:20:31] [main\/INFO]: ModLauncher 10.0.9+10.0.9+main.dcd20f30 starting: java version 17.0.10 by Eclipse Adoptium; OS Linux arch amd64 version 5.15.0-88-generic"
+                        }
+                    ]
+                },
+                "label": "Java version",
+                "value": "17.0.10"
+            },
+            {
                 "message": "Minecraft version: 20.4.155-beta",
                 "counter": 1,
                 "entry": {


### PR DESCRIPTION
This fixes #70.

It also fixes detecting Java Versions that aren't made by oracle