### PR TITLE
Paper: Detect problem "Plugin API version ... is lower than the minimum allowed version. "

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -85,5 +85,7 @@
   "type-crash-report": "Crash Report",
   "type-network-protocol-error-report": "Network Protocol Error Report",
   "type-unknown": "Unknown Log",
-  "forge-language-provider-version-problem": "The mod '{{mod-file}}' requires '{{required-version}}', but '{{found-version}}' is installed."
+  "forge-language-provider-version-problem": "The mod '{{mod-file}}' requires '{{required-version}}', but '{{found-version}}' is installed.",
+  "plugin-api-version-lower-than-allowed-problem": "The plugin '{{plugin-name}}' has an API version specified that is lower than the minimum allowed version.",
+  "change-minimum-api-version-solution": "Change 'minimum-api' in bukkit.yml to {{api-version}}, lower or even 'none'."
 }

--- a/src/Analyser/PaperAnalyser.php
+++ b/src/Analyser/PaperAnalyser.php
@@ -2,6 +2,7 @@
 
 namespace Aternos\Codex\Minecraft\Analyser;
 
+use Aternos\Codex\Minecraft\Analysis\Problem\Paper\ApiVersionLowerThanAllowedProblem;
 use Aternos\Codex\Minecraft\Analysis\Problem\Paper\VersionDowngradeProblem;
 
 /**
@@ -15,5 +16,6 @@ class PaperAnalyser extends BukkitAnalyser
     {
         parent::__construct();
         $this->addPossibleInsightClass(VersionDowngradeProblem::class);
+        $this->addPossibleInsightClass(ApiVersionLowerThanAllowedProblem::class);
     }
 }

--- a/src/Analysis/Problem/Paper/ApiVersionLowerThanAllowedProblem.php
+++ b/src/Analysis/Problem/Paper/ApiVersionLowerThanAllowedProblem.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Aternos\Codex\Minecraft\Analysis\Problem\Paper;
+
+use Aternos\Codex\Minecraft\Analysis\Solution\Bukkit\PluginInstallDifferentVersionSolution;
+use Aternos\Codex\Minecraft\Analysis\Solution\Bukkit\PluginRemoveSolution;
+use Aternos\Codex\Minecraft\Analysis\Solution\Paper\ChangeMinimumAllowedApiVersionSolution;
+use Aternos\Codex\Minecraft\Translator\Translator;
+
+/**
+ * Class ApiVersionLowerThanAllowedProblem
+ *
+ * @package Aternos\Codex\Minecraft\Analysis\Problem\Paper
+ */
+class ApiVersionLowerThanAllowedProblem extends PaperProblem
+{
+    protected ?string $pluginName = null;
+    protected ?string $pluginApiVersion = null;
+
+    /**
+     * Get a human-readable message
+     *
+     * @return string
+     */
+    public function getMessage(): string
+    {
+        return Translator::getInstance()->getTranslation("plugin-api-version-lower-than-allowed-problem", [
+            "plugin-name" => $this->getPluginName()
+        ]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getPatterns(): array
+    {
+        return [
+            '/Could not load plugin \'((?!\.jar).*)\.jar\' in folder \'[^\']+\''
+            . '\norg.bukkit.plugin.InvalidPluginException: Plugin API version (\d+\.\d+) is lower than the minimum allowed version\. Please update or replace it\./'
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setMatches(array $matches, mixed $patternKey): void
+    {
+        $this->pluginName = $matches[1];
+        $this->pluginApiVersion = $matches[2];
+
+        $this->addSolution((new PluginRemoveSolution())->setPluginName($this->getPluginName()));
+        $this->addSolution((new PluginInstallDifferentVersionSolution())->setPluginName($this->getPluginName()));
+        $this->addSolution((new ChangeMinimumAllowedApiVersionSolution())->setApiVersion($this->getPluginApiVersion()));
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPluginName(): ?string
+    {
+        return $this->pluginName;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPluginApiVersion(): ?string
+    {
+        return $this->pluginApiVersion;
+    }
+}

--- a/src/Analysis/Solution/Paper/ChangeMinimumAllowedApiVersionSolution.php
+++ b/src/Analysis/Solution/Paper/ChangeMinimumAllowedApiVersionSolution.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Aternos\Codex\Minecraft\Analysis\Solution\Paper;
+
+use Aternos\Codex\Minecraft\Translator\Translator;
+
+/**
+ * Class ChangeMinimumAllowedApiVersionSolution
+ *
+ * @package Aternos\Codex\Minecraft\Analysis\Solution\Paper
+ */
+class ChangeMinimumAllowedApiVersionSolution extends PaperSolution
+{
+
+    protected ?string $apiVersion = null;
+
+    /**
+     * @return string|null
+     */
+    public function getApiVersion(): ?string
+    {
+        return $this->apiVersion;
+    }
+
+    /**
+     * @param string $apiVersion
+     * @return $this
+     */
+    public function setApiVersion(string $apiVersion): static
+    {
+        $this->apiVersion = $apiVersion;
+        return $this;
+    }
+
+    /**
+     * Get the solution as a human-readable message
+     *
+     * @return string
+     */
+    public function getMessage(): string
+    {
+        return Translator::getInstance()->getTranslation("change-minimum-api-version-solution", [
+            "api-version" => $this->getApiVersion()
+        ]);
+    }
+}

--- a/test/data/Vanilla/Bukkit/Paper/paper-plugin-api-version-too-low-1-20-6.json
+++ b/test/data/Vanilla/Bukkit/Paper/paper-plugin-api-version-too-low-1-20-6.json
@@ -1,0 +1,518 @@
+{
+    "id": "paper\/server",
+    "name": "Paper",
+    "type": "Server Log",
+    "version": "1.20.6",
+    "title": "Paper 1.20.6 Server Log",
+    "entries": [
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:37] [ServerMain\/INFO]:",
+            "lines": [
+                {
+                    "number": 1,
+                    "content": "[04:57:37] [ServerMain\/INFO]: Environment: Environment[sessionHost=https:\/\/sessionserver.mojang.com, servicesHost=https:\/\/api.minecraftservices.com, name=PROD]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:39] [ServerMain\/INFO]:",
+            "lines": [
+                {
+                    "number": 2,
+                    "content": "[04:57:39] [ServerMain\/INFO]: Loaded 1175 recipes"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:39] [ServerMain\/INFO]:",
+            "lines": [
+                {
+                    "number": 3,
+                    "content": "[04:57:39] [ServerMain\/INFO]: Loaded 1276 advancements"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:39] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 4,
+                    "content": "[04:57:39] [Server thread\/INFO]: Starting minecraft server version 1.20.6"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:39] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 5,
+                    "content": "[04:57:39] [Server thread\/INFO]: Loading properties"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:39] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 6,
+                    "content": "[04:57:39] [Server thread\/INFO]: This server is running Paper version 1.20.6-148-ver\/1.20.6@20f5165 (2024-07-02T15:37:33Z) (Implementing API version 1.20.6-R0.1-SNAPSHOT)"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:40] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 7,
+                    "content": "[04:57:40] [Server thread\/INFO]: Server Ping Player Sample Count: 12"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:40] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 8,
+                    "content": "[04:57:40] [Server thread\/INFO]: Using 4 threads for Netty based IO"
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[04:57:40] [Server thread\/WARN]:",
+            "lines": [
+                {
+                    "number": 9,
+                    "content": "[04:57:40] [Server thread\/WARN]: [!] The timings profiler has been enabled but has been scheduled for removal from Paper in the future."
+                },
+                {
+                    "number": 10,
+                    "content": "    We recommend installing the spark profiler as a replacement: https:\/\/spark.lucko.me\/"
+                },
+                {
+                    "number": 11,
+                    "content": "    For more information please visit: https:\/\/github.com\/PaperMC\/Paper\/issues\/8948"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:40] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 12,
+                    "content": "[04:57:40] [Server thread\/INFO]: [ChunkTaskScheduler] Chunk system is using 1 I\/O threads, 1 worker threads, and gen parallelism of 1 threads"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:41] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 13,
+                    "content": "[04:57:41] [Server thread\/INFO]: Default game type: SURVIVAL"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:41] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 14,
+                    "content": "[04:57:41] [Server thread\/INFO]: Generating keypair"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:41] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 15,
+                    "content": "[04:57:41] [Server thread\/INFO]: Starting Minecraft server on *:20774"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:41] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 16,
+                    "content": "[04:57:41] [Server thread\/INFO]: Using epoll channel type"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:41] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 17,
+                    "content": "[04:57:41] [Server thread\/INFO]: Paper: Using libdeflate (Linux x86_64) compression from Velocity."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:41] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 18,
+                    "content": "[04:57:41] [Server thread\/INFO]: Paper: Using OpenSSL 3.0.x (Linux x86_64) cipher from Velocity."
+                }
+            ]
+        },
+        {
+            "level": 3,
+            "time": null,
+            "prefix": "[04:57:41] [Server thread\/ERROR]:",
+            "lines": [
+                {
+                    "number": 19,
+                    "content": "[04:57:41] [Server thread\/ERROR]: [ModernPluginLoadingStrategy] Could not load plugin 'worldedit-bukkit-7.3.4-beta-01.jar' in folder 'plugins\/.paper-remapped'"
+                },
+                {
+                    "number": 20,
+                    "content": "org.bukkit.plugin.InvalidPluginException: Plugin API version 1.20 is lower than the minimum allowed version. Please update or replace it."
+                },
+                {
+                    "number": 21,
+                    "content": "\tat org.bukkit.craftbukkit.util.CraftMagicNumbers.checkSupported(CraftMagicNumbers.java:394) ~[paper-1.20.6.jar:1.20.6-148-20f5165]"
+                },
+                {
+                    "number": 22,
+                    "content": "\tat io.papermc.paper.plugin.provider.type.spigot.SpigotPluginProvider.createInstance(SpigotPluginProvider.java:121) ~[paper-1.20.6.jar:1.20.6-148-20f5165]"
+                },
+                {
+                    "number": 23,
+                    "content": "\tat io.papermc.paper.plugin.provider.type.spigot.SpigotPluginProvider.createInstance(SpigotPluginProvider.java:35) ~[paper-1.20.6.jar:1.20.6-148-20f5165]"
+                },
+                {
+                    "number": 24,
+                    "content": "\tat io.papermc.paper.plugin.entrypoint.strategy.modern.ModernPluginLoadingStrategy.loadProviders(ModernPluginLoadingStrategy.java:116) ~[paper-1.20.6.jar:1.20.6-148-20f5165]"
+                },
+                {
+                    "number": 25,
+                    "content": "\tat io.papermc.paper.plugin.storage.SimpleProviderStorage.enter(SimpleProviderStorage.java:38) ~[paper-1.20.6.jar:1.20.6-148-20f5165]"
+                },
+                {
+                    "number": 26,
+                    "content": "\tat io.papermc.paper.plugin.entrypoint.LaunchEntryPointHandler.enter(LaunchEntryPointHandler.java:36) ~[paper-1.20.6.jar:1.20.6-148-20f5165]"
+                },
+                {
+                    "number": 27,
+                    "content": "\tat org.bukkit.craftbukkit.CraftServer.loadPlugins(CraftServer.java:532) ~[paper-1.20.6.jar:1.20.6-148-20f5165]"
+                },
+                {
+                    "number": 28,
+                    "content": "\tat net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:286) ~[paper-1.20.6.jar:1.20.6-148-20f5165]"
+                },
+                {
+                    "number": 29,
+                    "content": "\tat net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1136) ~[paper-1.20.6.jar:1.20.6-148-20f5165]"
+                },
+                {
+                    "number": 30,
+                    "content": "\tat net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:323) ~[paper-1.20.6.jar:1.20.6-148-20f5165]"
+                },
+                {
+                    "number": 31,
+                    "content": "\tat java.base\/java.lang.Thread.run(Thread.java:1583) ~[?:?]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:41] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 32,
+                    "content": "[04:57:41] [Server thread\/INFO]: Server permissions file permissions.yml is empty, ignoring it"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:41] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 33,
+                    "content": "[04:57:41] [Server thread\/INFO]: Preparing level \"world\""
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:41] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 34,
+                    "content": "[04:57:41] [Server thread\/INFO]: Preparing start region for dimension minecraft:overworld"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:43] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 35,
+                    "content": "[04:57:43] [Server thread\/INFO]: Time elapsed: 1416 ms"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:43] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 36,
+                    "content": "[04:57:43] [Server thread\/INFO]: Preparing start region for dimension minecraft:the_nether"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:43] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 37,
+                    "content": "[04:57:43] [Server thread\/INFO]: Time elapsed: 186 ms"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:43] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 38,
+                    "content": "[04:57:43] [Server thread\/INFO]: Preparing start region for dimension minecraft:the_end"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:43] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 39,
+                    "content": "[04:57:43] [Server thread\/INFO]: Time elapsed: 180 ms"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:43] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 40,
+                    "content": "[04:57:43] [Server thread\/INFO]: Starting GS4 status listener"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:43] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 41,
+                    "content": "[04:57:43] [Server thread\/INFO]: Thread Query Listener started"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:43] [Query Listener #1\/INFO]:",
+            "lines": [
+                {
+                    "number": 42,
+                    "content": "[04:57:43] [Query Listener #1\/INFO]: Query running on 0.0.0.0:9898"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:43] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 43,
+                    "content": "[04:57:43] [Server thread\/INFO]: JMX monitoring enabled"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:43] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 44,
+                    "content": "[04:57:43] [Server thread\/INFO]: Running delayed init tasks"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:43] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 45,
+                    "content": "[04:57:43] [Server thread\/INFO]: Done (4.304s)! For help, type \"help\""
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[04:57:43] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 46,
+                    "content": "[04:57:43] [Server thread\/INFO]: Timings Reset"
+                },
+                {
+                    "number": 47,
+                    "content": ""
+                }
+            ]
+        }
+    ],
+    "analysis": {
+        "problems": [
+            {
+                "message": "The plugin 'worldedit-bukkit-7.3.4-beta-01' has an API version specified that is lower than the minimum allowed version.",
+                "counter": 1,
+                "entry": {
+                    "level": 3,
+                    "time": null,
+                    "prefix": "[04:57:41] [Server thread\/ERROR]:",
+                    "lines": [
+                        {
+                            "number": 19,
+                            "content": "[04:57:41] [Server thread\/ERROR]: [ModernPluginLoadingStrategy] Could not load plugin 'worldedit-bukkit-7.3.4-beta-01.jar' in folder 'plugins\/.paper-remapped'"
+                        },
+                        {
+                            "number": 20,
+                            "content": "org.bukkit.plugin.InvalidPluginException: Plugin API version 1.20 is lower than the minimum allowed version. Please update or replace it."
+                        },
+                        {
+                            "number": 21,
+                            "content": "\tat org.bukkit.craftbukkit.util.CraftMagicNumbers.checkSupported(CraftMagicNumbers.java:394) ~[paper-1.20.6.jar:1.20.6-148-20f5165]"
+                        },
+                        {
+                            "number": 22,
+                            "content": "\tat io.papermc.paper.plugin.provider.type.spigot.SpigotPluginProvider.createInstance(SpigotPluginProvider.java:121) ~[paper-1.20.6.jar:1.20.6-148-20f5165]"
+                        },
+                        {
+                            "number": 23,
+                            "content": "\tat io.papermc.paper.plugin.provider.type.spigot.SpigotPluginProvider.createInstance(SpigotPluginProvider.java:35) ~[paper-1.20.6.jar:1.20.6-148-20f5165]"
+                        },
+                        {
+                            "number": 24,
+                            "content": "\tat io.papermc.paper.plugin.entrypoint.strategy.modern.ModernPluginLoadingStrategy.loadProviders(ModernPluginLoadingStrategy.java:116) ~[paper-1.20.6.jar:1.20.6-148-20f5165]"
+                        },
+                        {
+                            "number": 25,
+                            "content": "\tat io.papermc.paper.plugin.storage.SimpleProviderStorage.enter(SimpleProviderStorage.java:38) ~[paper-1.20.6.jar:1.20.6-148-20f5165]"
+                        },
+                        {
+                            "number": 26,
+                            "content": "\tat io.papermc.paper.plugin.entrypoint.LaunchEntryPointHandler.enter(LaunchEntryPointHandler.java:36) ~[paper-1.20.6.jar:1.20.6-148-20f5165]"
+                        },
+                        {
+                            "number": 27,
+                            "content": "\tat org.bukkit.craftbukkit.CraftServer.loadPlugins(CraftServer.java:532) ~[paper-1.20.6.jar:1.20.6-148-20f5165]"
+                        },
+                        {
+                            "number": 28,
+                            "content": "\tat net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:286) ~[paper-1.20.6.jar:1.20.6-148-20f5165]"
+                        },
+                        {
+                            "number": 29,
+                            "content": "\tat net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1136) ~[paper-1.20.6.jar:1.20.6-148-20f5165]"
+                        },
+                        {
+                            "number": 30,
+                            "content": "\tat net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:323) ~[paper-1.20.6.jar:1.20.6-148-20f5165]"
+                        },
+                        {
+                            "number": 31,
+                            "content": "\tat java.base\/java.lang.Thread.run(Thread.java:1583) ~[?:?]"
+                        }
+                    ]
+                },
+                "solutions": [
+                    {
+                        "message": "Remove the plugin 'worldedit-bukkit-7.3.4-beta-01'."
+                    },
+                    {
+                        "message": "Install a different version of the plugin 'worldedit-bukkit-7.3.4-beta-01'."
+                    },
+                    {
+                        "message": "Change 'minimum-api' in bukkit.yml to 1.20, lower or even 'none'."
+                    }
+                ]
+            }
+        ],
+        "information": [
+            {
+                "message": "Minecraft version: 1.20.6",
+                "counter": 1,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[04:57:39] [Server thread\/INFO]:",
+                    "lines": [
+                        {
+                            "number": 4,
+                            "content": "[04:57:39] [Server thread\/INFO]: Starting minecraft server version 1.20.6"
+                        }
+                    ]
+                },
+                "label": "Minecraft version",
+                "value": "1.20.6"
+            }
+        ]
+    }
+}

--- a/test/data/Vanilla/Bukkit/Paper/paper-plugin-api-version-too-low-1-20-6.log
+++ b/test/data/Vanilla/Bukkit/Paper/paper-plugin-api-version-too-low-1-20-6.log
@@ -1,0 +1,46 @@
+[04:57:37] [ServerMain/INFO]: Environment: Environment[sessionHost=https://sessionserver.mojang.com, servicesHost=https://api.minecraftservices.com, name=PROD]
+[04:57:39] [ServerMain/INFO]: Loaded 1175 recipes
+[04:57:39] [ServerMain/INFO]: Loaded 1276 advancements
+[04:57:39] [Server thread/INFO]: Starting minecraft server version 1.20.6
+[04:57:39] [Server thread/INFO]: Loading properties
+[04:57:39] [Server thread/INFO]: This server is running Paper version 1.20.6-148-ver/1.20.6@20f5165 (2024-07-02T15:37:33Z) (Implementing API version 1.20.6-R0.1-SNAPSHOT)
+[04:57:40] [Server thread/INFO]: Server Ping Player Sample Count: 12
+[04:57:40] [Server thread/INFO]: Using 4 threads for Netty based IO
+[04:57:40] [Server thread/WARN]: [!] The timings profiler has been enabled but has been scheduled for removal from Paper in the future.
+    We recommend installing the spark profiler as a replacement: https://spark.lucko.me/
+    For more information please visit: https://github.com/PaperMC/Paper/issues/8948
+[04:57:40] [Server thread/INFO]: [ChunkTaskScheduler] Chunk system is using 1 I/O threads, 1 worker threads, and gen parallelism of 1 threads
+[04:57:41] [Server thread/INFO]: Default game type: SURVIVAL
+[04:57:41] [Server thread/INFO]: Generating keypair
+[04:57:41] [Server thread/INFO]: Starting Minecraft server on *:20774
+[04:57:41] [Server thread/INFO]: Using epoll channel type
+[04:57:41] [Server thread/INFO]: Paper: Using libdeflate (Linux x86_64) compression from Velocity.
+[04:57:41] [Server thread/INFO]: Paper: Using OpenSSL 3.0.x (Linux x86_64) cipher from Velocity.
+[04:57:41] [Server thread/ERROR]: [ModernPluginLoadingStrategy] Could not load plugin 'worldedit-bukkit-7.3.4-beta-01.jar' in folder 'plugins/.paper-remapped'
+org.bukkit.plugin.InvalidPluginException: Plugin API version 1.20 is lower than the minimum allowed version. Please update or replace it.
+	at org.bukkit.craftbukkit.util.CraftMagicNumbers.checkSupported(CraftMagicNumbers.java:394) ~[paper-1.20.6.jar:1.20.6-148-20f5165]
+	at io.papermc.paper.plugin.provider.type.spigot.SpigotPluginProvider.createInstance(SpigotPluginProvider.java:121) ~[paper-1.20.6.jar:1.20.6-148-20f5165]
+	at io.papermc.paper.plugin.provider.type.spigot.SpigotPluginProvider.createInstance(SpigotPluginProvider.java:35) ~[paper-1.20.6.jar:1.20.6-148-20f5165]
+	at io.papermc.paper.plugin.entrypoint.strategy.modern.ModernPluginLoadingStrategy.loadProviders(ModernPluginLoadingStrategy.java:116) ~[paper-1.20.6.jar:1.20.6-148-20f5165]
+	at io.papermc.paper.plugin.storage.SimpleProviderStorage.enter(SimpleProviderStorage.java:38) ~[paper-1.20.6.jar:1.20.6-148-20f5165]
+	at io.papermc.paper.plugin.entrypoint.LaunchEntryPointHandler.enter(LaunchEntryPointHandler.java:36) ~[paper-1.20.6.jar:1.20.6-148-20f5165]
+	at org.bukkit.craftbukkit.CraftServer.loadPlugins(CraftServer.java:532) ~[paper-1.20.6.jar:1.20.6-148-20f5165]
+	at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:286) ~[paper-1.20.6.jar:1.20.6-148-20f5165]
+	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1136) ~[paper-1.20.6.jar:1.20.6-148-20f5165]
+	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:323) ~[paper-1.20.6.jar:1.20.6-148-20f5165]
+	at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
+[04:57:41] [Server thread/INFO]: Server permissions file permissions.yml is empty, ignoring it
+[04:57:41] [Server thread/INFO]: Preparing level "world"
+[04:57:41] [Server thread/INFO]: Preparing start region for dimension minecraft:overworld
+[04:57:43] [Server thread/INFO]: Time elapsed: 1416 ms
+[04:57:43] [Server thread/INFO]: Preparing start region for dimension minecraft:the_nether
+[04:57:43] [Server thread/INFO]: Time elapsed: 186 ms
+[04:57:43] [Server thread/INFO]: Preparing start region for dimension minecraft:the_end
+[04:57:43] [Server thread/INFO]: Time elapsed: 180 ms
+[04:57:43] [Server thread/INFO]: Starting GS4 status listener
+[04:57:43] [Server thread/INFO]: Thread Query Listener started
+[04:57:43] [Query Listener #1/INFO]: Query running on 0.0.0.0:9898
+[04:57:43] [Server thread/INFO]: JMX monitoring enabled
+[04:57:43] [Server thread/INFO]: Running delayed init tasks
+[04:57:43] [Server thread/INFO]: Done (4.304s)! For help, type "help"
+[04:57:43] [Server thread/INFO]: Timings Reset

--- a/test/tests/Logs/AutoLogsTest.php
+++ b/test/tests/Logs/AutoLogsTest.php
@@ -398,6 +398,16 @@ class AutoLogsTest extends \PHPUnit\Framework\TestCase
      * @return void
      * @throws Exception
      */
+    public function test_paper_plugin_api_version_too_low_1_20_6(): void
+    {
+        $log = new TestLog('Vanilla/Bukkit/Paper/paper-plugin-api-version-too-low-1-20-6.log');
+        $this->assertStringEqualsFile($log->getExpectedPath(), $log->getOutput(), $log->getLogPath());
+    }
+
+    /**
+     * @return void
+     * @throws Exception
+     */
     public function test_paper_plugin_dependency_1_18_2_duplicate(): void
     {
         $log = new TestLog('Vanilla/Bukkit/Paper/paper-plugin-dependency-1-18-2-duplicate.log');


### PR DESCRIPTION
This PR adds a new detection for the problem:
`Plugin API version ... is lower than the minimum allowed version. `

This problem has 3 solutions:
- `PluginRemoveSolution`
- `PluginInstallDifferentVersionSolution`
- And the new `ChangeMinimumAllowedApiVersionSolution`