### PR TITLE
Use MultiPatternDetector for all client logs and crash reports

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=8.1.0",
-        "aternos/codex": "^2.1.1",
+        "aternos/codex": "^2.2.0",
         "ext-json": "*"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,27 +4,27 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ff0a1442e0c85a1d614e81ebe9f12ff8",
+    "content-hash": "db96acc55b7bc25d09d91d43fe0d416c",
     "packages": [
         {
             "name": "aternos/codex",
-            "version": "v2.1.1",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aternosorg/codex.git",
-                "reference": "e14a34d63bd4d16ffa46bfed6a98e2bda8e822f1"
+                "reference": "8f7615e98ff001cc7e268165c1daf717e2fdc9cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aternosorg/codex/zipball/e14a34d63bd4d16ffa46bfed6a98e2bda8e822f1",
-                "reference": "e14a34d63bd4d16ffa46bfed6a98e2bda8e822f1",
+                "url": "https://api.github.com/repos/aternosorg/codex/zipball/8f7615e98ff001cc7e268165c1daf717e2fdc9cb",
+                "reference": "8f7615e98ff001cc7e268165c1daf717e2fdc9cb",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "autoload": {
@@ -45,9 +45,9 @@
             "description": "PHP library to read, parse, print and analyse log files.",
             "support": {
                 "issues": "https://github.com/aternosorg/codex/issues",
-                "source": "https://github.com/aternosorg/codex/tree/v2.1.1"
+                "source": "https://github.com/aternosorg/codex/tree/v2.2.0"
             },
-            "time": "2024-01-09T16:20:53+00:00"
+            "time": "2024-09-11T12:33:08+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Log/Minecraft/Vanilla/Bukkit/Folia/FoliaCrashReport.php
+++ b/src/Log/Minecraft/Vanilla/Bukkit/Folia/FoliaCrashReport.php
@@ -3,7 +3,7 @@
 namespace Aternos\Codex\Minecraft\Log\Minecraft\Vanilla\Bukkit\Folia;
 
 use Aternos\Codex\Detective\DetectorInterface;
-use Aternos\Codex\Detective\SinglePatternDetector;
+use Aternos\Codex\Detective\MultiPatternDetector;
 use Aternos\Codex\Minecraft\Log\Minecraft\Vanilla\VanillaCrashReportTrait;
 use Aternos\Codex\Minecraft\Log\Type\CrashReportLogTypeInterface;
 
@@ -21,6 +21,9 @@ class FoliaCrashReport extends FoliaLog implements CrashReportLogTypeInterface
      */
     public static function getDetectors(): array
     {
-        return [(new SinglePatternDetector())->setPattern("/---- Minecraft Crash Report ----(\n.*)*\n\s+Running: Folia version git-Folia/m")];
+        return [(new MultiPatternDetector())
+            ->addPattern("/^---- Minecraft Crash Report ----$/")
+            ->addPattern("/^\tRunning: Folia version git-Folia/m")
+        ];
     }
 }

--- a/src/Log/Minecraft/Vanilla/Bukkit/Paper/PaperCrashReportLog.php
+++ b/src/Log/Minecraft/Vanilla/Bukkit/Paper/PaperCrashReportLog.php
@@ -3,7 +3,7 @@
 namespace Aternos\Codex\Minecraft\Log\Minecraft\Vanilla\Bukkit\Paper;
 
 use Aternos\Codex\Detective\DetectorInterface;
-use Aternos\Codex\Detective\SinglePatternDetector;
+use Aternos\Codex\Detective\MultiPatternDetector;
 use Aternos\Codex\Minecraft\Log\Minecraft\Vanilla\VanillaCrashReportTrait;
 use Aternos\Codex\Minecraft\Log\Type\CrashReportLogTypeInterface;
 
@@ -21,6 +21,9 @@ class PaperCrashReportLog extends PaperLog implements CrashReportLogTypeInterfac
      */
     public static function getDetectors(): array
     {
-        return [(new SinglePatternDetector())->setPattern("/---- Minecraft Crash Report ----(\n.*)*\n\s+Running: Paper version git-Paper/m")];
+        return [(new MultiPatternDetector())
+            ->addPattern("/^---- Minecraft Crash Report ----$/m")
+            ->addPattern("/^\s+Running: Paper version git-Paper/m")
+        ];
     }
 }

--- a/src/Log/Minecraft/Vanilla/Bukkit/Purpur/PurpurCrashReportLog.php
+++ b/src/Log/Minecraft/Vanilla/Bukkit/Purpur/PurpurCrashReportLog.php
@@ -3,7 +3,7 @@
 namespace Aternos\Codex\Minecraft\Log\Minecraft\Vanilla\Bukkit\Purpur;
 
 use Aternos\Codex\Detective\DetectorInterface;
-use Aternos\Codex\Detective\SinglePatternDetector;
+use Aternos\Codex\Detective\MultiPatternDetector;
 use Aternos\Codex\Minecraft\Log\Minecraft\Vanilla\VanillaCrashReportTrait;
 use Aternos\Codex\Minecraft\Log\Type\CrashReportLogTypeInterface;
 
@@ -21,6 +21,9 @@ class PurpurCrashReportLog extends PurpurLog implements CrashReportLogTypeInterf
      */
     public static function getDetectors(): array
     {
-        return [(new SinglePatternDetector())->setPattern("/---- Minecraft Crash Report ----(\n.*)*\n\s+Running: Purpur version git-Purpur/m")];
+        return [(new MultiPatternDetector())
+            ->addPattern("/^---- Minecraft Crash Report ----$/m")
+            ->addPattern("/^\tRunning: Purpur version git-Purpur/m")
+        ];
     }
 }

--- a/src/Log/Minecraft/Vanilla/Fabric/FabricClientLog.php
+++ b/src/Log/Minecraft/Vanilla/Fabric/FabricClientLog.php
@@ -3,7 +3,7 @@
 namespace Aternos\Codex\Minecraft\Log\Minecraft\Vanilla\Fabric;
 
 use Aternos\Codex\Detective\DetectorInterface;
-use Aternos\Codex\Detective\SinglePatternDetector;
+use Aternos\Codex\Detective\MultiPatternDetector;
 use Aternos\Codex\Minecraft\Log\Type\ClientLogTypeInterface;
 
 /**
@@ -19,7 +19,9 @@ class FabricClientLog extends FabricLog implements ClientLogTypeInterface
     public static function getDetectors(): array
     {
         return [
-            (new SinglePatternDetector())->setPattern('#^\[[\d:]+\] \[main\/INFO\](?:\:| \(FabricLoader/GameProvider\)) Loading Minecraft [^ \n]+ with Fabric Loader [^ \n]+(\n.*)*\n\[[\d:]+\] \[(?:Render thread|main)\/INFO\](?:\:| \(Minecraft\)) Setting user: \w+#m'),
+            (new MultiPatternDetector())
+                ->addPattern('#^\[[\d:]+\] \[main\/INFO\](?:\:| \(FabricLoader/GameProvider\)) Loading Minecraft [^ \n]+ with Fabric Loader [^ \n]+#')
+                ->addPattern('#^\[[\d:]+\] \[(?:Render thread|main)\/INFO\](?:\:| \(Minecraft\)) Setting user: \w+#m')
         ];
     }
 }

--- a/src/Log/Minecraft/Vanilla/Fabric/FabricCrashReportLog.php
+++ b/src/Log/Minecraft/Vanilla/Fabric/FabricCrashReportLog.php
@@ -3,7 +3,7 @@
 namespace Aternos\Codex\Minecraft\Log\Minecraft\Vanilla\Fabric;
 
 use Aternos\Codex\Detective\DetectorInterface;
-use Aternos\Codex\Detective\SinglePatternDetector;
+use Aternos\Codex\Detective\MultiPatternDetector;
 use Aternos\Codex\Minecraft\Analyser\Report\CrashReport\FabricCrashReportAnalyser;
 use Aternos\Codex\Minecraft\Analyser\Report\CrashReport\MinecraftCrashReportAnalyser;
 use Aternos\Codex\Minecraft\Log\Minecraft\Vanilla\VanillaCrashReportTrait;
@@ -24,9 +24,15 @@ class FabricCrashReportLog extends FabricLog implements CrashReportLogTypeInterf
     public static function getDetectors(): array
     {
         return [
-            (new SinglePatternDetector())->setPattern("/---- Minecraft Crash Report ----(\n.*)*\n\t(?:Known )?server brands?: fabric/im"),
-            (new SinglePatternDetector())->setPattern("/---- Minecraft Crash Report ----(\n.*)*\n\tIs Modded: Definitely; Client brand changed to 'fabric'/im"),
-            (new SinglePatternDetector())->setPattern("/---- Minecraft Crash Report ----(\n.*)*\n\tIs Modded: Definitely; Server brand changed to 'fabric'/im"),
+            (new MultiPatternDetector())
+                ->addPattern("/^---- Minecraft Crash Report ----$/m")
+                ->addPattern("/^\t(?:Known )?server brands?: fabric$/im"),
+            (new MultiPatternDetector())
+                ->addPattern("/^---- Minecraft Crash Report ----$/m")
+                ->addPattern("/^\tIs Modded: Definitely; Client brand changed to 'fabric'$/im"),
+            (new MultiPatternDetector())
+                ->addPattern("/^---- Minecraft Crash Report ----$/m")
+                ->addPattern("/^\tIs Modded: Definitely; Server brand changed to 'fabric'$/im"),
         ];
     }
 

--- a/src/Log/Minecraft/Vanilla/Forge/Arclight/ArclightCrashReportLog.php
+++ b/src/Log/Minecraft/Vanilla/Forge/Arclight/ArclightCrashReportLog.php
@@ -3,12 +3,12 @@
 namespace Aternos\Codex\Minecraft\Log\Minecraft\Vanilla\Forge\Arclight;
 
 use Aternos\Codex\Detective\DetectorInterface;
-use Aternos\Codex\Detective\SinglePatternDetector;
+use Aternos\Codex\Detective\MultiPatternDetector;
 use Aternos\Codex\Minecraft\Log\Minecraft\Vanilla\VanillaCrashReportTrait;
 use Aternos\Codex\Minecraft\Log\Type\CrashReportLogTypeInterface;
 
 /**
- * Class MohistCrashReportLog
+ * Class ArclightCrashReportLog
  *
  * @package Aternos\Codex\Minecraft\Log\Minecraft\Vanilla\Forge\Mohist
  */
@@ -22,8 +22,15 @@ class ArclightCrashReportLog extends ArclightLog implements CrashReportLogTypeIn
     public static function getDetectors(): array
     {
         return [
-            (new SinglePatternDetector())->setPattern("/---- Minecraft Crash Report ----(\n.*)*\n\tKnown server brands:( [a-zA-Z])* arclight/m"),
-            (new SinglePatternDetector())->setPattern("/---- Minecraft Crash Report ----(\n.*)*\n\tIs Modded: Definitely; Server brand changed to 'arclight'/im")
+            (new MultiPatternDetector())
+                ->addPattern("/^---- Minecraft Crash Report ----$/m")
+                ->addPattern("/^\t(?:Known )?server brands?: arclight/im"),
+            (new MultiPatternDetector())
+                ->addPattern("/^---- Minecraft Crash Report ----$/m")
+                ->addPattern("/^\tIs Modded: Definitely; Client brand changed to 'arclight'$/im"),
+            (new MultiPatternDetector())
+                ->addPattern("/^---- Minecraft Crash Report ----$/m")
+                ->addPattern("/^\tIs Modded: Definitely; Server brand changed to 'arclight'$/im"),
         ];
     }
 }

--- a/src/Log/Minecraft/Vanilla/Forge/ForgeClientLog.php
+++ b/src/Log/Minecraft/Vanilla/Forge/ForgeClientLog.php
@@ -3,7 +3,7 @@
 namespace Aternos\Codex\Minecraft\Log\Minecraft\Vanilla\Forge;
 
 use Aternos\Codex\Detective\DetectorInterface;
-use Aternos\Codex\Detective\SinglePatternDetector;
+use Aternos\Codex\Detective\MultiPatternDetector;
 use Aternos\Codex\Minecraft\Log\Type\ClientLogTypeInterface;
 
 /**
@@ -19,8 +19,12 @@ class ForgeClientLog extends ForgeLog implements ClientLogTypeInterface
     public static function getDetectors(): array
     {
         return [
-            (new SinglePatternDetector())->setPattern('/^\[[^\]]+\] \[main\/INFO\]( \[[^\]]+\])?: ModLauncher running: .*--fml.forgeVersion.*(\n.*)*\n\[[^\]]+\] \[main\/INFO\]( \[[^\]]+\])?: Launching target \'(fml|forge)client\' with arguments.*$/m'),
-            (new SinglePatternDetector())->setPattern('/^\[[^\]]+\] \[main\/INFO\]( \[[^\]]+\])?: Forge Mod Loader version.*(\n.*)*\n\[[^\]]+\] \[main\/INFO\]( \[[^\]]+\])?: Launching wrapped minecraft \{net\.minecraft\.client/m')
+            (new MultiPatternDetector())
+                ->addPattern('/^\[[^\]]+\] \[main\/INFO\]( \[[^\]]+\])?: ModLauncher running: .*--fml.forgeVersion/m')
+                ->addPattern('/^\[[^\]]+\] \[main\/INFO\]( \[[^\]]+\])?: Launching target \'(fml|forge)client\' with arguments/m'),
+            (new MultiPatternDetector())
+                ->addPattern('/^\[[^\]]+\] \[main\/INFO\]( \[[^\]]+\])?: Forge Mod Loader version/m')
+                ->addPattern('/^\[[^\]]+\] \[main\/INFO\]( \[[^\]]+\])?: Launching wrapped minecraft \{net\.minecraft\.client/m')
         ];
     }
 }

--- a/src/Log/Minecraft/Vanilla/Forge/ForgeCrashReportLog.php
+++ b/src/Log/Minecraft/Vanilla/Forge/ForgeCrashReportLog.php
@@ -3,7 +3,7 @@
 namespace Aternos\Codex\Minecraft\Log\Minecraft\Vanilla\Forge;
 
 use Aternos\Codex\Detective\DetectorInterface;
-use Aternos\Codex\Detective\SinglePatternDetector;
+use Aternos\Codex\Detective\MultiPatternDetector;
 use Aternos\Codex\Minecraft\Analyser\Report\CrashReport\ForgeCrashReportAnalyser;
 use Aternos\Codex\Minecraft\Analyser\Report\CrashReport\MinecraftCrashReportAnalyser;
 use Aternos\Codex\Minecraft\Log\Minecraft\Vanilla\VanillaCrashReportTrait;
@@ -24,10 +24,12 @@ class ForgeCrashReportLog extends ForgeLog implements CrashReportLogTypeInterfac
     public static function getDetectors(): array
     {
         return [
-            (new SinglePatternDetector())->setPattern("/---- Minecraft Crash Report ----(\n.*)*\n\tFML:/m"),
-            (new SinglePatternDetector())->setPattern("/---- Minecraft Crash Report ----(\n.*)*\n\tIs Modded: Definitely; Client brand changed to '(?:fml,)?forge'/im"),
-            (new SinglePatternDetector())->setPattern("/---- Minecraft Crash Report ----(\n.*)*\n\tIs Modded: Definitely; Server brand changed to '(?:fml,)?forge'/im"),
-
+            (new MultiPatternDetector())
+                ->addPattern("/---- Minecraft Crash Report ----$/m")
+                ->addPattern("/^\tIs Modded: Definitely; Client brand changed to '(?:fml,)?forge'/im"),
+            (new MultiPatternDetector())
+                ->addPattern("/---- Minecraft Crash Report ----$/m")
+                ->addPattern("/^\tIs Modded: Definitely; Server brand changed to '(?:fml,)?forge'/im"),
         ];
     }
 

--- a/src/Log/Minecraft/Vanilla/NeoForge/NeoForgeClientLog.php
+++ b/src/Log/Minecraft/Vanilla/NeoForge/NeoForgeClientLog.php
@@ -3,7 +3,7 @@
 namespace Aternos\Codex\Minecraft\Log\Minecraft\Vanilla\NeoForge;
 
 use Aternos\Codex\Detective\DetectorInterface;
-use Aternos\Codex\Detective\SinglePatternDetector;
+use Aternos\Codex\Detective\MultiPatternDetector;
 use Aternos\Codex\Minecraft\Log\Type\ClientLogTypeInterface;
 
 class NeoForgeClientLog extends NeoForgeLog implements ClientLogTypeInterface
@@ -14,7 +14,9 @@ class NeoForgeClientLog extends NeoForgeLog implements ClientLogTypeInterface
     public static function getDetectors(): array
     {
         return [
-            (new SinglePatternDetector())->setPattern('/^\[[^\]]+\] \[main\/INFO\]( \[[^\]]+\])?: ModLauncher running: .*--fml.neoForgeVersion.*(\n.*)*\n\[[^\]]+\] \[main\/INFO\]( \[[^\]]+\])?: Launching target \'(fml|forge)client\' with arguments.*$/m')
+            (new MultiPatternDetector())
+                ->addPattern('/^\[[^\]]+\] \[main\/INFO\]( \[[^\]]+\])?: ModLauncher running: .*--fml.neoForgeVersion/m')
+                ->addPattern('/^\[[^\]]+\] \[main\/INFO\]( \[[^\]]+\])?: Launching target \'(fml|forge)client\' with arguments/m'),
         ];
     }
 }

--- a/src/Log/Minecraft/Vanilla/NeoForge/NeoForgeCrashReportLog.php
+++ b/src/Log/Minecraft/Vanilla/NeoForge/NeoForgeCrashReportLog.php
@@ -3,7 +3,7 @@
 namespace Aternos\Codex\Minecraft\Log\Minecraft\Vanilla\NeoForge;
 
 use Aternos\Codex\Detective\DetectorInterface;
-use Aternos\Codex\Detective\SinglePatternDetector;
+use Aternos\Codex\Detective\MultiPatternDetector;
 use Aternos\Codex\Minecraft\Analyser\Report\CrashReport\MinecraftCrashReportAnalyser;
 use Aternos\Codex\Minecraft\Analyser\Report\CrashReport\NeoForgeCrashReportAnalyser;
 use Aternos\Codex\Minecraft\Log\Minecraft\Vanilla\VanillaCrashReportTrait;
@@ -18,7 +18,11 @@ class NeoForgeCrashReportLog extends NeoForgeLog implements CrashReportLogTypeIn
      */
     public static function getDetectors(): array
     {
-        return [(new SinglePatternDetector())->setPattern("/---- Minecraft Crash Report ----(\n.*)*\n\tNeoForge:/m")];
+        return [
+            (new MultiPatternDetector())
+                ->addPattern("/^---- Minecraft Crash Report ----$/m")
+                ->addPattern("/^\tNeoForge: net\.neoforged:/m"),
+        ];
     }
 
 

--- a/src/Log/Minecraft/Vanilla/Quilt/QuiltClientLog.php
+++ b/src/Log/Minecraft/Vanilla/Quilt/QuiltClientLog.php
@@ -3,7 +3,7 @@
 namespace Aternos\Codex\Minecraft\Log\Minecraft\Vanilla\Quilt;
 
 use Aternos\Codex\Detective\DetectorInterface;
-use Aternos\Codex\Detective\SinglePatternDetector;
+use Aternos\Codex\Detective\MultiPatternDetector;
 use Aternos\Codex\Minecraft\Log\Type\ClientLogTypeInterface;
 
 /**
@@ -19,7 +19,9 @@ class QuiltClientLog extends QuiltLog implements ClientLogTypeInterface
     public static function getDetectors(): array
     {
         return [
-            (new SinglePatternDetector())->setPattern('/\[[\d:]+\] \[main\/INFO\]: Loading Minecraft [^ \n]+ with Quilt Loader [^ \n]+(\n.*)*\n\[[\d:]+\] \[Render thread\/INFO\]: Setting user: \w+/'),
+            (new MultiPatternDetector())
+                ->addPattern('/^\[[\d:]+\] \[main\/INFO\]: Loading Minecraft [^ \n]+ with Quilt Loader [^ \n]+/')
+                ->addPattern('/^\[[\d:]+\] \[(?:Render thread|main)\/INFO\]: Setting user: \w+/m')
         ];
     }
 }

--- a/src/Log/Minecraft/Vanilla/Quilt/QuiltCrashReportLog.php
+++ b/src/Log/Minecraft/Vanilla/Quilt/QuiltCrashReportLog.php
@@ -3,7 +3,7 @@
 namespace Aternos\Codex\Minecraft\Log\Minecraft\Vanilla\Quilt;
 
 use Aternos\Codex\Detective\DetectorInterface;
-use Aternos\Codex\Detective\SinglePatternDetector;
+use Aternos\Codex\Detective\MultiPatternDetector;
 use Aternos\Codex\Minecraft\Analyser\Report\CrashReport\MinecraftCrashReportAnalyser;
 use Aternos\Codex\Minecraft\Analyser\Report\CrashReport\QuiltCrashReportAnalyser;
 use Aternos\Codex\Minecraft\Log\Minecraft\Vanilla\VanillaCrashReportTrait;
@@ -19,9 +19,15 @@ class QuiltCrashReportLog extends QuiltLog implements CrashReportLogTypeInterfac
     public static function getDetectors(): array
     {
         return [
-            (new SinglePatternDetector())->setPattern("/---- Minecraft Crash Report ----(\n.*)*\n\t(?:Known )?server brands?: quilt/im"),
-            (new SinglePatternDetector())->setPattern("/---- Minecraft Crash Report ----(\n.*)*\n\tIs Modded: Definitely; Client brand changed to 'quilt'/im"),
-            (new SinglePatternDetector())->setPattern("/---- Minecraft Crash Report ----(\n.*)*\n\tIs Modded: Definitely; Server brand changed to 'quilt'/im")
+            (new MultiPatternDetector())
+                ->addPattern("/^---- Minecraft Crash Report ----$/m")
+                ->addPattern("/^\t(?:Known )?server brands?: quilt/im"),
+            (new MultiPatternDetector())
+                ->addPattern("/^---- Minecraft Crash Report ----$/m")
+                ->addPattern("/^\tIs Modded: Definitely; Client brand changed to 'quilt'$/im"),
+            (new MultiPatternDetector())
+                ->addPattern("/^---- Minecraft Crash Report ----$/m")
+                ->addPattern("/^\tIs Modded: Definitely; Server brand changed to 'quilt'$/im"),
         ];
     }
 


### PR DESCRIPTION
This PR replaces all occurrences of `SinglePatternDetector` with `MultiPatternDetector` to get rid of one long, complex and inefficient regular expression and replace it with two regular expressions that are easier to read, understand and (hopefully) faster to parse.

This PR updates aternos/codex to 2.2.0 to use the new `MultiPatternDetector` introduced in https://github.com/aternosorg/codex/pull/21.

This PR also fixes #87 as we no longer use expressions like `*(\n.*)*`, so the regular expression parser should no longer encounter errors like `JIT stack limit exhausted`.

This PR also contains these changes:
- Add detection for client crash reports from Arclight: Add regex `Is Modded: Definitely; Client brand changed to 'arclight'`
- Remove old / unnecessary detection for client crash reports from Forge: Remove regex `/---- Minecraft Crash Report ----(\n.*)*\n\tFML:/m`
- Change regex to a more precise one for client crash reports from NeoForge: Use `/^\tNeoForge: net\.neoforged:/m` instead of `\tNeoForge:/m`