### PR TITLE
Paper: "Ambiguous plugin name" problem in 1.21.1

### DIFF
--- a/src/Analysis/Problem/Bukkit/AmbiguousPluginNameProblem.php
+++ b/src/Analysis/Problem/Bukkit/AmbiguousPluginNameProblem.php
@@ -48,7 +48,7 @@ class AmbiguousPluginNameProblem extends BukkitProblem
     {
         return [
             '/Ambiguous plugin name `(\S+)\' for files `(plugins\/[^\']+)\' and `(plugins\/[^\']+)\' in `plugins\'/',
-            '/Ambiguous plugin name \'(\S+)\' for files \'(plugins\/[^\']+)\' and \'(plugins\/[^\']+)\' in \'plugins\'/'
+            '/Ambiguous plugin name \'(\S+)\' for files \'(plugins\/[^\']+)\' and \'(plugins\/[^\']+)\' in \'(plugins[^\']*)\'/'
         ];
     }
 

--- a/test/data/Vanilla/Bukkit/Paper/paper-ambiguous-plugin-name-1-21-1.json
+++ b/test/data/Vanilla/Bukkit/Paper/paper-ambiguous-plugin-name-1-21-1.json
@@ -1,0 +1,719 @@
+{
+    "id": "paper\/server",
+    "name": "Paper",
+    "type": "Server Log",
+    "version": "1.21.1",
+    "title": "Paper 1.21.1 Server Log",
+    "entries": [
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:38:44] [ServerMain\/INFO]:",
+            "lines": [
+                {
+                    "number": 1,
+                    "content": "[18:38:44] [ServerMain\/INFO]: [bootstrap] Running Java 21 (OpenJDK 64-Bit Server VM 21.0.3+9-LTS; Eclipse Adoptium Temurin-21.0.3+9) on Linux 5.15.0-117-generic (amd64)"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:38:44] [ServerMain\/INFO]:",
+            "lines": [
+                {
+                    "number": 2,
+                    "content": "[18:38:44] [ServerMain\/INFO]: [bootstrap] Loading Paper 1.21.1-115-master@ba3c29b (2024-09-30T02:19:06Z) for Minecraft 1.21.1"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:38:44] [ServerMain\/INFO]:",
+            "lines": [
+                {
+                    "number": 3,
+                    "content": "[18:38:44] [ServerMain\/INFO]: [PluginInitializerManager] Initializing plugins..."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:38:45] [Paper Plugin Remapper Thread - 0\/INFO]:",
+            "lines": [
+                {
+                    "number": 4,
+                    "content": "[18:38:45] [Paper Plugin Remapper Thread - 0\/INFO]: [ReobfServer] Remapping server..."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:38:51] [Paper Plugin Remapper Thread - 0\/INFO]:",
+            "lines": [
+                {
+                    "number": 5,
+                    "content": "[18:38:51] [Paper Plugin Remapper Thread - 0\/INFO]: [ReobfServer] Done remapping server in 5972ms."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:38:51] [Paper Plugin Remapper Thread - 3\/INFO]:",
+            "lines": [
+                {
+                    "number": 6,
+                    "content": "[18:38:51] [Paper Plugin Remapper Thread - 3\/INFO]: [PluginRemapper] Remapping plugin 'plugins\/worldedit-bukkit-7.3.4.jar'..."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:38:51] [Paper Plugin Remapper Thread - 2\/INFO]:",
+            "lines": [
+                {
+                    "number": 7,
+                    "content": "[18:38:51] [Paper Plugin Remapper Thread - 2\/INFO]: [PluginRemapper] Remapping plugin 'plugins\/worldedit-bukkit-7.3.6.jar'..."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:38:54] [Paper Plugin Remapper Thread - 3\/INFO]:",
+            "lines": [
+                {
+                    "number": 8,
+                    "content": "[18:38:54] [Paper Plugin Remapper Thread - 3\/INFO]: [PluginRemapper] Done remapping plugin 'plugins\/worldedit-bukkit-7.3.4.jar' in 2339ms."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:38:54] [Paper Plugin Remapper Thread - 2\/INFO]:",
+            "lines": [
+                {
+                    "number": 9,
+                    "content": "[18:38:54] [Paper Plugin Remapper Thread - 2\/INFO]: [PluginRemapper] Done remapping plugin 'plugins\/worldedit-bukkit-7.3.6.jar' in 2356ms."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:38:54] [ServerMain\/INFO]:",
+            "lines": [
+                {
+                    "number": 10,
+                    "content": "[18:38:54] [ServerMain\/INFO]: [PluginInitializerManager] Initialized 2 plugins"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:38:54] [ServerMain\/INFO]:",
+            "lines": [
+                {
+                    "number": 11,
+                    "content": "[18:38:54] [ServerMain\/INFO]: [PluginInitializerManager] Bukkit plugins (2):"
+                },
+                {
+                    "number": 12,
+                    "content": " - WorldEdit (7.3.4+6823-6263244), WorldEdit (7.3.6+6892-3d660b8)"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:38:58] [ServerMain\/INFO]:",
+            "lines": [
+                {
+                    "number": 13,
+                    "content": "[18:38:58] [ServerMain\/INFO]: Environment: Environment[sessionHost=https:\/\/sessionserver.mojang.com, servicesHost=https:\/\/api.minecraftservices.com, name=PROD]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:38:58] [ServerMain\/INFO]:",
+            "lines": [
+                {
+                    "number": 14,
+                    "content": "[18:38:58] [ServerMain\/INFO]: Found new data pack file\/bukkit, loading it automatically"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:38:58] [ServerMain\/INFO]:",
+            "lines": [
+                {
+                    "number": 15,
+                    "content": "[18:38:58] [ServerMain\/INFO]: Found new data pack paper, loading it automatically"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:38:59] [ServerMain\/INFO]:",
+            "lines": [
+                {
+                    "number": 16,
+                    "content": "[18:38:59] [ServerMain\/INFO]: No existing world data, creating new world"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:38:59] [ServerMain\/INFO]:",
+            "lines": [
+                {
+                    "number": 17,
+                    "content": "[18:38:59] [ServerMain\/INFO]: Loaded 1290 recipes"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:00] [ServerMain\/INFO]:",
+            "lines": [
+                {
+                    "number": 18,
+                    "content": "[18:39:00] [ServerMain\/INFO]: Loaded 1399 advancements"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:00] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 19,
+                    "content": "[18:39:00] [Server thread\/INFO]: Starting minecraft server version 1.21.1"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:00] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 20,
+                    "content": "[18:39:00] [Server thread\/INFO]: Loading properties"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:00] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 21,
+                    "content": "[18:39:00] [Server thread\/INFO]: This server is running Paper version 1.21.1-115-master@ba3c29b (2024-09-30T02:19:06Z) (Implementing API version 1.21.1-R0.1-SNAPSHOT)"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:01] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 22,
+                    "content": "[18:39:01] [Server thread\/INFO]: [spark] This server bundles the spark profiler. For more information please visit https:\/\/docs.papermc.io\/paper\/profiling"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:01] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 23,
+                    "content": "[18:39:01] [Server thread\/INFO]: Server Ping Player Sample Count: 12"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:01] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 24,
+                    "content": "[18:39:01] [Server thread\/INFO]: Using 4 threads for Netty based IO"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:02] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 25,
+                    "content": "[18:39:02] [Server thread\/INFO]: [ChunkTaskScheduler] Chunk system is using 1 I\/O threads, 1 worker threads, and population gen parallelism of 1 threads"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:02] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 26,
+                    "content": "[18:39:02] [Server thread\/INFO]: Default game type: SURVIVAL"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:02] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 27,
+                    "content": "[18:39:02] [Server thread\/INFO]: Generating keypair"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:02] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 28,
+                    "content": "[18:39:02] [Server thread\/INFO]: Starting Minecraft server on *:16754"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:02] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 29,
+                    "content": "[18:39:02] [Server thread\/INFO]: Using epoll channel type"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:02] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 30,
+                    "content": "[18:39:02] [Server thread\/INFO]: Paper: Using libdeflate (Linux x86_64) compression from Velocity."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:02] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 31,
+                    "content": "[18:39:02] [Server thread\/INFO]: Paper: Using OpenSSL 3.x.x (Linux x86_64) cipher from Velocity."
+                }
+            ]
+        },
+        {
+            "level": 3,
+            "time": null,
+            "prefix": "[18:39:02] [Server thread\/ERROR]:",
+            "lines": [
+                {
+                    "number": 32,
+                    "content": "[18:39:02] [Server thread\/ERROR]: [ModernPluginLoadingStrategy] Ambiguous plugin name 'WorldEdit' for files 'plugins\/.paper-remapped\/worldedit-bukkit-7.3.6.jar' and 'plugins\/.paper-remapped\/worldedit-bukkit-7.3.4.jar' in 'plugins\/.paper-remapped'"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:02] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 33,
+                    "content": "[18:39:02] [Server thread\/INFO]: [WorldEdit] Loading server plugin WorldEdit v7.3.6+6892-3d660b8"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:05] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 34,
+                    "content": "[18:39:05] [Server thread\/INFO]: Got request to register class com.sk89q.worldedit.bukkit.BukkitServerInterface with WorldEdit [com.sk89q.worldedit.extension.platform.PlatformManager@5bb9c8b9]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:05] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 35,
+                    "content": "[18:39:05] [Server thread\/INFO]: [WorldEdit] Default configuration file written: config.yml"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:05] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 36,
+                    "content": "[18:39:05] [Server thread\/INFO]: [WorldEdit] Enabling WorldEdit v7.3.6+6892-3d660b8"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:05] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 37,
+                    "content": "[18:39:05] [Server thread\/INFO]: Registering commands with com.sk89q.worldedit.bukkit.BukkitServerInterface"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:05] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 38,
+                    "content": "[18:39:05] [Server thread\/INFO]: WEPIF: Updated config file"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:05] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 39,
+                    "content": "[18:39:05] [Server thread\/INFO]: WEPIF: Using the Bukkit Permissions API."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:06] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 40,
+                    "content": "[18:39:06] [Server thread\/INFO]: Using com.sk89q.worldedit.bukkit.adapter.impl.v1_21.PaperweightAdapter as the Bukkit adapter"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:07] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 41,
+                    "content": "[18:39:07] [Server thread\/INFO]: Preparing level \"world\""
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:20] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 42,
+                    "content": "[18:39:20] [Server thread\/INFO]: Preparing start region for dimension minecraft:overworld"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:26] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 43,
+                    "content": "[18:39:26] [Server thread\/INFO]: Time elapsed: 5858 ms"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:26] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 44,
+                    "content": "[18:39:26] [Server thread\/INFO]: Preparing start region for dimension minecraft:the_nether"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:28] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 45,
+                    "content": "[18:39:28] [Server thread\/INFO]: Time elapsed: 2239 ms"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:28] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 46,
+                    "content": "[18:39:28] [Server thread\/INFO]: Preparing start region for dimension minecraft:the_end"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:28] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 47,
+                    "content": "[18:39:28] [Server thread\/INFO]: Time elapsed: 608 ms"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:28] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 48,
+                    "content": "[18:39:28] [Server thread\/INFO]: [spark] Starting background profiler..."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:29] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 49,
+                    "content": "[18:39:29] [Server thread\/INFO]: Done preparing level \"world\" (21.464s)"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:29] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 50,
+                    "content": "[18:39:29] [Server thread\/INFO]: Starting GS4 status listener"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:29] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 51,
+                    "content": "[18:39:29] [Server thread\/INFO]: Thread Query Listener started"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:29] [Query Listener #1\/INFO]:",
+            "lines": [
+                {
+                    "number": 52,
+                    "content": "[18:39:29] [Query Listener #1\/INFO]: Query running on 0.0.0.0:9898"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:29] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 53,
+                    "content": "[18:39:29] [Server thread\/INFO]: JMX monitoring enabled"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:29] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 54,
+                    "content": "[18:39:29] [Server thread\/INFO]: Running delayed init tasks"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:29] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 55,
+                    "content": "[18:39:29] [Server thread\/INFO]: Done (45.127s)! For help, type \"help\""
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:29] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 56,
+                    "content": "[18:39:29] [Server thread\/INFO]: *************************************************************************************"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:29] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 57,
+                    "content": "[18:39:29] [Server thread\/INFO]: This is the first time you're starting this server."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:29] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 58,
+                    "content": "[18:39:29] [Server thread\/INFO]: It's recommended you read our 'Getting Started' documentation for guidance."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:29] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 59,
+                    "content": "[18:39:29] [Server thread\/INFO]: View this and more helpful information here: https:\/\/docs.papermc.io\/paper\/next-steps"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:29] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 60,
+                    "content": "[18:39:29] [Server thread\/INFO]: *************************************************************************************"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:39:29] [Server thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 61,
+                    "content": "[18:39:29] [Server thread\/INFO]: Timings Reset"
+                }
+            ]
+        }
+    ],
+    "analysis": {
+        "problems": [
+            {
+                "message": "There are multiple plugin files for the plugin name 'WorldEdit': 'worldedit-bukkit-7.3.6.jar' and 'worldedit-bukkit-7.3.4.jar'.",
+                "counter": 1,
+                "entry": {
+                    "level": 3,
+                    "time": null,
+                    "prefix": "[18:39:02] [Server thread\/ERROR]:",
+                    "lines": [
+                        {
+                            "number": 32,
+                            "content": "[18:39:02] [Server thread\/ERROR]: [ModernPluginLoadingStrategy] Ambiguous plugin name 'WorldEdit' for files 'plugins\/.paper-remapped\/worldedit-bukkit-7.3.6.jar' and 'plugins\/.paper-remapped\/worldedit-bukkit-7.3.4.jar' in 'plugins\/.paper-remapped'"
+                        }
+                    ]
+                },
+                "solutions": [
+                    {
+                        "message": "Delete the file 'plugins\/.paper-remapped\/worldedit-bukkit-7.3.6.jar'."
+                    },
+                    {
+                        "message": "Delete the file 'plugins\/.paper-remapped\/worldedit-bukkit-7.3.4.jar'."
+                    }
+                ]
+            }
+        ],
+        "information": [
+            {
+                "message": "Minecraft version: 1.21.1",
+                "counter": 1,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[18:39:00] [Server thread\/INFO]:",
+                    "lines": [
+                        {
+                            "number": 19,
+                            "content": "[18:39:00] [Server thread\/INFO]: Starting minecraft server version 1.21.1"
+                        }
+                    ]
+                },
+                "label": "Minecraft version",
+                "value": "1.21.1"
+            }
+        ]
+    }
+}

--- a/test/data/Vanilla/Bukkit/Paper/paper-ambiguous-plugin-name-1-21-1.log
+++ b/test/data/Vanilla/Bukkit/Paper/paper-ambiguous-plugin-name-1-21-1.log
@@ -1,0 +1,61 @@
+[18:38:44] [ServerMain/INFO]: [bootstrap] Running Java 21 (OpenJDK 64-Bit Server VM 21.0.3+9-LTS; Eclipse Adoptium Temurin-21.0.3+9) on Linux 5.15.0-117-generic (amd64)
+[18:38:44] [ServerMain/INFO]: [bootstrap] Loading Paper 1.21.1-115-master@ba3c29b (2024-09-30T02:19:06Z) for Minecraft 1.21.1
+[18:38:44] [ServerMain/INFO]: [PluginInitializerManager] Initializing plugins...
+[18:38:45] [Paper Plugin Remapper Thread - 0/INFO]: [ReobfServer] Remapping server...
+[18:38:51] [Paper Plugin Remapper Thread - 0/INFO]: [ReobfServer] Done remapping server in 5972ms.
+[18:38:51] [Paper Plugin Remapper Thread - 3/INFO]: [PluginRemapper] Remapping plugin 'plugins/worldedit-bukkit-7.3.4.jar'...
+[18:38:51] [Paper Plugin Remapper Thread - 2/INFO]: [PluginRemapper] Remapping plugin 'plugins/worldedit-bukkit-7.3.6.jar'...
+[18:38:54] [Paper Plugin Remapper Thread - 3/INFO]: [PluginRemapper] Done remapping plugin 'plugins/worldedit-bukkit-7.3.4.jar' in 2339ms.
+[18:38:54] [Paper Plugin Remapper Thread - 2/INFO]: [PluginRemapper] Done remapping plugin 'plugins/worldedit-bukkit-7.3.6.jar' in 2356ms.
+[18:38:54] [ServerMain/INFO]: [PluginInitializerManager] Initialized 2 plugins
+[18:38:54] [ServerMain/INFO]: [PluginInitializerManager] Bukkit plugins (2):
+ - WorldEdit (7.3.4+6823-6263244), WorldEdit (7.3.6+6892-3d660b8)
+[18:38:58] [ServerMain/INFO]: Environment: Environment[sessionHost=https://sessionserver.mojang.com, servicesHost=https://api.minecraftservices.com, name=PROD]
+[18:38:58] [ServerMain/INFO]: Found new data pack file/bukkit, loading it automatically
+[18:38:58] [ServerMain/INFO]: Found new data pack paper, loading it automatically
+[18:38:59] [ServerMain/INFO]: No existing world data, creating new world
+[18:38:59] [ServerMain/INFO]: Loaded 1290 recipes
+[18:39:00] [ServerMain/INFO]: Loaded 1399 advancements
+[18:39:00] [Server thread/INFO]: Starting minecraft server version 1.21.1
+[18:39:00] [Server thread/INFO]: Loading properties
+[18:39:00] [Server thread/INFO]: This server is running Paper version 1.21.1-115-master@ba3c29b (2024-09-30T02:19:06Z) (Implementing API version 1.21.1-R0.1-SNAPSHOT)
+[18:39:01] [Server thread/INFO]: [spark] This server bundles the spark profiler. For more information please visit https://docs.papermc.io/paper/profiling
+[18:39:01] [Server thread/INFO]: Server Ping Player Sample Count: 12
+[18:39:01] [Server thread/INFO]: Using 4 threads for Netty based IO
+[18:39:02] [Server thread/INFO]: [ChunkTaskScheduler] Chunk system is using 1 I/O threads, 1 worker threads, and population gen parallelism of 1 threads
+[18:39:02] [Server thread/INFO]: Default game type: SURVIVAL
+[18:39:02] [Server thread/INFO]: Generating keypair
+[18:39:02] [Server thread/INFO]: Starting Minecraft server on *:16754
+[18:39:02] [Server thread/INFO]: Using epoll channel type
+[18:39:02] [Server thread/INFO]: Paper: Using libdeflate (Linux x86_64) compression from Velocity.
+[18:39:02] [Server thread/INFO]: Paper: Using OpenSSL 3.x.x (Linux x86_64) cipher from Velocity.
+[18:39:02] [Server thread/ERROR]: [ModernPluginLoadingStrategy] Ambiguous plugin name 'WorldEdit' for files 'plugins/.paper-remapped/worldedit-bukkit-7.3.6.jar' and 'plugins/.paper-remapped/worldedit-bukkit-7.3.4.jar' in 'plugins/.paper-remapped'
+[18:39:02] [Server thread/INFO]: [WorldEdit] Loading server plugin WorldEdit v7.3.6+6892-3d660b8
+[18:39:05] [Server thread/INFO]: Got request to register class com.sk89q.worldedit.bukkit.BukkitServerInterface with WorldEdit [com.sk89q.worldedit.extension.platform.PlatformManager@5bb9c8b9]
+[18:39:05] [Server thread/INFO]: [WorldEdit] Default configuration file written: config.yml
+[18:39:05] [Server thread/INFO]: [WorldEdit] Enabling WorldEdit v7.3.6+6892-3d660b8
+[18:39:05] [Server thread/INFO]: Registering commands with com.sk89q.worldedit.bukkit.BukkitServerInterface
+[18:39:05] [Server thread/INFO]: WEPIF: Updated config file
+[18:39:05] [Server thread/INFO]: WEPIF: Using the Bukkit Permissions API.
+[18:39:06] [Server thread/INFO]: Using com.sk89q.worldedit.bukkit.adapter.impl.v1_21.PaperweightAdapter as the Bukkit adapter
+[18:39:07] [Server thread/INFO]: Preparing level "world"
+[18:39:20] [Server thread/INFO]: Preparing start region for dimension minecraft:overworld
+[18:39:26] [Server thread/INFO]: Time elapsed: 5858 ms
+[18:39:26] [Server thread/INFO]: Preparing start region for dimension minecraft:the_nether
+[18:39:28] [Server thread/INFO]: Time elapsed: 2239 ms
+[18:39:28] [Server thread/INFO]: Preparing start region for dimension minecraft:the_end
+[18:39:28] [Server thread/INFO]: Time elapsed: 608 ms
+[18:39:28] [Server thread/INFO]: [spark] Starting background profiler...
+[18:39:29] [Server thread/INFO]: Done preparing level "world" (21.464s)
+[18:39:29] [Server thread/INFO]: Starting GS4 status listener
+[18:39:29] [Server thread/INFO]: Thread Query Listener started
+[18:39:29] [Query Listener #1/INFO]: Query running on 0.0.0.0:9898
+[18:39:29] [Server thread/INFO]: JMX monitoring enabled
+[18:39:29] [Server thread/INFO]: Running delayed init tasks
+[18:39:29] [Server thread/INFO]: Done (45.127s)! For help, type "help"
+[18:39:29] [Server thread/INFO]: *************************************************************************************
+[18:39:29] [Server thread/INFO]: This is the first time you're starting this server.
+[18:39:29] [Server thread/INFO]: It's recommended you read our 'Getting Started' documentation for guidance.
+[18:39:29] [Server thread/INFO]: View this and more helpful information here: https://docs.papermc.io/paper/next-steps
+[18:39:29] [Server thread/INFO]: *************************************************************************************
+[18:39:29] [Server thread/INFO]: Timings Reset

--- a/test/tests/Logs/AutoLogsTest.php
+++ b/test/tests/Logs/AutoLogsTest.php
@@ -368,6 +368,16 @@ class AutoLogsTest extends \PHPUnit\Framework\TestCase
      * @return void
      * @throws Exception
      */
+    public function test_paper_ambiguous_plugin_name_1_21_1(): void
+    {
+        $log = new TestLog('Vanilla/Bukkit/Paper/paper-ambiguous-plugin-name-1-21-1.log');
+        $this->assertStringEqualsFile($log->getExpectedPath(), $log->getOutput(), $log->getLogPath());
+    }
+
+    /**
+     * @return void
+     * @throws Exception
+     */
     public function test_paper_metaspace(): void
     {
         $log = new TestLog('Vanilla/Bukkit/Paper/paper-metaspace.log');


### PR DESCRIPTION
In Paper 1.21.1 plugins can be in the subfolder: `plugins/.paper-remapped/` (example log attached)
This PR adjusts the regex for the error message "Ambiguous plugin name..."