### PR TITLE
Detect + add latest logs for Forge 1.21.3 (client+server) and NeoForge 1.21.3 (client+server)

### DIFF
--- a/src/Analysis/Information/Forge/ForgeVanillaVersionInformation.php
+++ b/src/Analysis/Information/Forge/ForgeVanillaVersionInformation.php
@@ -17,9 +17,10 @@ class ForgeVanillaVersionInformation extends VanillaVersionInformation
     public static function getPatterns(): array
     {
         return array_merge(parent::getPatterns(), [
-            "/Received command line version data {0,2}: MC Version: '(". static::$vanillaVersionPattern .")'/",
-            "/--fml\.mcVersion, (". static::$vanillaVersionPattern .")/",
-            "/Forge Mod Loader version ". ForgeVersionInformation::getVersionPattern() ." for Minecraft (". static::$vanillaVersionPattern.") loading/",
+            "/Received command line version data {0,2}: MC Version: '(" . static::$vanillaVersionPattern . ")'/",
+            "/--fml\.mcVersion, (" . static::$vanillaVersionPattern . ")/",
+            "/Forge Mod Loader version " . ForgeVersionInformation::getVersionPattern() . " for Minecraft (" . static::$vanillaVersionPattern . ") loading/",
+            "/Forge mod loading, version " . ForgeVersionInformation::getVersionPattern() . ", for MC (" . static::$vanillaVersionPattern . ")/",
         ]);
     }
 }

--- a/src/Log/Minecraft/Vanilla/Forge/ForgeClientLog.php
+++ b/src/Log/Minecraft/Vanilla/Forge/ForgeClientLog.php
@@ -23,6 +23,9 @@ class ForgeClientLog extends ForgeLog implements ClientLogTypeInterface
                 ->addPattern('/^\[[^\]]+\] \[main\/INFO\]( \[[^\]]+\])?: ModLauncher running: .*--fml.forgeVersion/m')
                 ->addPattern('/^\[[^\]]+\] \[main\/INFO\]( \[[^\]]+\])?: Launching target \'(fml|forge)client\' with arguments/m'),
             (new MultiPatternDetector())
+                ->addPattern('/^\[[^\]]+\] \[main\/INFO\]( \[[^\]]+\])?: ModLauncher running: .*--version, forge-/m')
+                ->addPattern('/^\[[^\]]+\] \[main\/INFO\]( \[[^\]]+\])?: Launching target \'forge_client\' with arguments/m'),
+            (new MultiPatternDetector())
                 ->addPattern('/^\[[^\]]+\] \[main\/INFO\]( \[[^\]]+\])?: Forge Mod Loader version/m')
                 ->addPattern('/^\[[^\]]+\] \[main\/INFO\]( \[[^\]]+\])?: Launching wrapped minecraft \{net\.minecraft\.client/m')
         ];

--- a/test/data/Vanilla/Forge/Arclight/arclight-1192.json
+++ b/test/data/Vanilla/Forge/Arclight/arclight-1192.json
@@ -2860,7 +2860,7 @@
         "information": [
             {
                 "message": "Minecraft version: 1.19.2",
-                "counter": 2,
+                "counter": 3,
                 "entry": {
                     "level": 6,
                     "time": null,

--- a/test/data/Vanilla/Forge/Mohist/mohist-1-16-5.json
+++ b/test/data/Vanilla/Forge/Mohist/mohist-1-16-5.json
@@ -418,7 +418,7 @@
         "information": [
             {
                 "message": "Minecraft version: 1.16.5",
-                "counter": 2,
+                "counter": 3,
                 "entry": {
                     "level": 6,
                     "time": null,

--- a/test/data/Vanilla/Forge/Mohist/mohist-1-18-2.json
+++ b/test/data/Vanilla/Forge/Mohist/mohist-1-18-2.json
@@ -2404,7 +2404,7 @@
         "information": [
             {
                 "message": "Minecraft version: 1.18.2",
-                "counter": 2,
+                "counter": 3,
                 "entry": {
                     "level": 6,
                     "time": null,

--- a/test/data/Vanilla/Forge/forge-1-21-3-client.json
+++ b/test/data/Vanilla/Forge/forge-1-21-3-client.json
@@ -1,9 +1,9 @@
 {
-    "id": "vanilla\/client",
-    "name": "Vanilla",
+    "id": "forge\/client",
+    "name": "Forge",
     "type": "Client Log",
-    "version": null,
-    "title": "Vanilla Client Log",
+    "version": "1.21.3",
+    "title": "Forge 1.21.3 Client Log",
     "entries": [
         {
             "level": 6,
@@ -723,6 +723,58 @@
     ],
     "analysis": {
         "problems": [],
-        "information": []
+        "information": [
+            {
+                "message": "Java version: 21.0.3",
+                "counter": 1,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[16:56:56] [main\/INFO]:",
+                    "lines": [
+                        {
+                            "number": 3,
+                            "content": "[16:56:56] [main\/INFO]: ModLauncher 10.2.2 starting: java version 21.0.3 by Microsoft; OS Linux arch amd64 version 5.15.167-1-MANJARO"
+                        }
+                    ]
+                },
+                "label": "Java version",
+                "value": "21.0.3"
+            },
+            {
+                "message": "Minecraft version: 1.21.3",
+                "counter": 1,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[16:57:03] [modloading-worker-0\/INFO]:",
+                    "lines": [
+                        {
+                            "number": 37,
+                            "content": "[16:57:03] [modloading-worker-0\/INFO]: Forge mod loading, version 53.0.7, for MC 1.21.3 with MCP 20241025.112443"
+                        }
+                    ]
+                },
+                "label": "Minecraft version",
+                "value": "1.21.3"
+            },
+            {
+                "message": "Forge version: 53.0.7",
+                "counter": 1,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[16:57:03] [modloading-worker-0\/INFO]:",
+                    "lines": [
+                        {
+                            "number": 38,
+                            "content": "[16:57:03] [modloading-worker-0\/INFO]: MinecraftForge v53.0.7 Initialized"
+                        }
+                    ]
+                },
+                "label": "Forge version",
+                "value": "53.0.7"
+            }
+        ]
     }
 }

--- a/test/data/Vanilla/Forge/forge-1-21-3-client.json
+++ b/test/data/Vanilla/Forge/forge-1-21-3-client.json
@@ -1,0 +1,728 @@
+{
+    "id": "vanilla\/client",
+    "name": "Vanilla",
+    "type": "Client Log",
+    "version": null,
+    "title": "Vanilla Client Log",
+    "entries": [
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:56:56] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 1,
+                    "content": "[16:56:56] [main\/INFO]: ModLauncher running: args [--username, Aternos, --version, forge-53.0.7, --gameDir, \/home\/paulv\/Documents\/curseforge\/minecraft\/Instances\/Forge 1.21.3, --assetsDir, \/home\/paulv\/Documents\/curseforge\/minecraft\/Install\/assets, --assetIndex, 18, --uuid, ac4a2732dd44408b8d4ee0b6de14b2c1, --accessToken, **********, --clientId, H3rxt6E4CfbDHImeBFoaQM3a\/SDrPrAWTr5jBeWUTe\/PLfFDgBP7ZgIZNg==, --xuid, 2535449932625433, --userType, msa, --versionType, release, --width, 1024, --height, 768, --quickPlayPath, \/home\/paulv\/Documents\/curseforge\/minecraft\/Install\/quickPlay\/java\/1730217414833.json, --launchTarget, forge_client]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:56:56] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 2,
+                    "content": "[16:56:56] [main\/INFO]: JVM identified as Microsoft OpenJDK 64-Bit Server VM 21.0.3+9-LTS"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:56:56] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 3,
+                    "content": "[16:56:56] [main\/INFO]: ModLauncher 10.2.2 starting: java version 21.0.3 by Microsoft; OS Linux arch amd64 version 5.15.167-1-MANJARO"
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[16:56:56] [main\/WARN]:",
+            "lines": [
+                {
+                    "number": 4,
+                    "content": "[16:56:56] [main\/WARN]: Configuration file \/home\/paulv\/Documents\/curseforge\/minecraft\/Instances\/Forge 1.21.3\/config\/fml.toml is not correct. Correcting"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:56:56] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 5,
+                    "content": "[16:56:56] [main\/INFO]: Incorrect key [earlyWindowSkipGLVersions] was corrected from null to []"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:56:56] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 6,
+                    "content": "[16:56:56] [main\/INFO]: Incorrect key [earlyWindowLogHelpMessage] was corrected from null to true"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:56:56] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 7,
+                    "content": "[16:56:56] [main\/INFO]: Incorrect key [earlyWindowSquir] was corrected from null to false"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:56:56] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 8,
+                    "content": "[16:56:56] [main\/INFO]: Incorrect key [earlyWindowShowCPU] was corrected from null to false"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:56:56] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 9,
+                    "content": "[16:56:56] [main\/INFO]: Loading ImmediateWindowProvider fmlearlywindow"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:56:56] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 10,
+                    "content": "[16:56:56] [main\/INFO]: Trying GL version 4.6"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:56:56] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 11,
+                    "content": "[16:56:56] [main\/INFO]: If this message is the only thing at the bottom of your log before a crash, you probably have a driver issue."
+                },
+                {
+                    "number": 12,
+                    "content": ""
+                },
+                {
+                    "number": 13,
+                    "content": "Possible solutions:"
+                },
+                {
+                    "number": 14,
+                    "content": "A) Make sure Minecraft is set to prefer high performance graphics in the OS and\/or driver control panel"
+                },
+                {
+                    "number": 15,
+                    "content": "B) Check for driver updates on the graphics brand's website"
+                },
+                {
+                    "number": 16,
+                    "content": "C) Try reinstalling your graphics drivers"
+                },
+                {
+                    "number": 17,
+                    "content": "D) If still not working after trying all of the above, ask for further help on the Forge forums or Discord"
+                },
+                {
+                    "number": 18,
+                    "content": ""
+                },
+                {
+                    "number": 19,
+                    "content": "You can safely ignore this message if the game starts up successfully."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:56:56] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 20,
+                    "content": "[16:56:56] [main\/INFO]: Requested GL version 4.6 got version 4.6"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:56:57] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 21,
+                    "content": "[16:56:57] [main\/INFO]: SpongePowered MIXIN Subsystem Version=0.8.7 Source=jar:file:\/\/\/home\/paulv\/Documents\/curseforge\/minecraft\/Install\/libraries\/org\/spongepowered\/mixin\/0.8.7\/mixin-0.8.7.jar!\/ Service=ModLauncher Env=CLIENT"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:56:57] [EarlyDisplay\/INFO]:",
+            "lines": [
+                {
+                    "number": 22,
+                    "content": "[16:56:57] [EarlyDisplay\/INFO]: GL info: Mesa Intel(R) UHD Graphics (TGL GT1) GL version 4.6 (Core Profile) Mesa 24.2.4-arch1.0.1, Intel"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:56:57] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 23,
+                    "content": "[16:56:57] [main\/INFO]: Found mod file forge-1.21.3-53.0.7-client.jar of type MOD with provider net.minecraftforge.fml.loading.moddiscovery.MinecraftLocator@47e4d9d0"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:56:57] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 24,
+                    "content": "[16:56:57] [main\/INFO]: Found mod file forge-1.21.3-53.0.7-universal.jar of type MOD with provider net.minecraftforge.fml.loading.moddiscovery.ClasspathLocator@4beeb0e"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:56:57] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 25,
+                    "content": "[16:56:57] [main\/INFO]: Found mod file javafmllanguage-1.21.3-53.0.7.jar of type LANGPROVIDER with provider net.minecraftforge.fml.loading.moddiscovery.ClasspathLocator@4beeb0e"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:56:57] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 26,
+                    "content": "[16:56:57] [main\/INFO]: Found mod file lowcodelanguage-1.21.3-53.0.7.jar of type LANGPROVIDER with provider net.minecraftforge.fml.loading.moddiscovery.ClasspathLocator@4beeb0e"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:56:57] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 27,
+                    "content": "[16:56:57] [main\/INFO]: Found mod file fmlcore-1.21.3-53.0.7.jar of type LIBRARY with provider net.minecraftforge.fml.loading.moddiscovery.ClasspathLocator@4beeb0e"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:56:57] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 28,
+                    "content": "[16:56:57] [main\/INFO]: Found mod file mclanguage-1.21.3-53.0.7.jar of type LANGPROVIDER with provider net.minecraftforge.fml.loading.moddiscovery.ClasspathLocator@4beeb0e"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:56:57] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 29,
+                    "content": "[16:56:57] [main\/INFO]: No dependencies to load found. Skipping!"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:56:57] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 30,
+                    "content": "[16:56:57] [main\/INFO]: Launching target 'forge_client' with arguments [--version, forge-53.0.7, --gameDir, \/home\/paulv\/Documents\/curseforge\/minecraft\/Instances\/Forge 1.21.3, --assetsDir, \/home\/paulv\/Documents\/curseforge\/minecraft\/Install\/assets, --uuid, ac4a2732dd44408b8d4ee0b6de14b2c1, --username, Aternos, --assetIndex, 18, --accessToken, **********, --clientId, H3rxt6E4CfbDHImeBFoaQM3a\/SDrPrAWTr5jBeWUTe\/PLfFDgBP7ZgIZNg==, --xuid, 2535449932625433, --userType, msa, --versionType, release, --width, 1024, --height, 768, --quickPlayPath, \/home\/paulv\/Documents\/curseforge\/minecraft\/Install\/quickPlay\/java\/1730217414833.json]"
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[16:56:58] [main\/WARN]:",
+            "lines": [
+                {
+                    "number": 31,
+                    "content": "[16:56:58] [main\/WARN]: Configuration conflict: there is more than one oshi.properties file on the classpath: [jar:file:\/\/\/home\/paulv\/Documents\/curseforge\/minecraft\/Install\/libraries\/com\/github\/oshi\/oshi-core\/6.4.10\/oshi-core-6.4.10.jar!\/oshi.properties, jar:file:\/home\/paulv\/Documents\/curseforge\/minecraft\/Install\/libraries\/com\/github\/oshi\/oshi-core\/6.4.10\/oshi-core-6.4.10.jar!\/oshi.properties, jar:file:\/\/\/home\/paulv\/Documents\/curseforge\/minecraft\/Install\/libraries\/com\/github\/oshi\/oshi-core\/6.4.10\/oshi-core-6.4.10.jar!\/oshi.properties, jar:file:\/home\/paulv\/Documents\/curseforge\/minecraft\/Install\/libraries\/com\/github\/oshi\/oshi-core\/6.4.10\/oshi-core-6.4.10.jar!\/oshi.properties]"
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[16:56:58] [main\/WARN]:",
+            "lines": [
+                {
+                    "number": 32,
+                    "content": "[16:56:58] [main\/WARN]: Configuration conflict: there is more than one oshi.architecture.properties file on the classpath: [jar:file:\/\/\/home\/paulv\/Documents\/curseforge\/minecraft\/Install\/libraries\/com\/github\/oshi\/oshi-core\/6.4.10\/oshi-core-6.4.10.jar!\/oshi.architecture.properties, jar:file:\/home\/paulv\/Documents\/curseforge\/minecraft\/Install\/libraries\/com\/github\/oshi\/oshi-core\/6.4.10\/oshi-core-6.4.10.jar!\/oshi.architecture.properties, jar:file:\/\/\/home\/paulv\/Documents\/curseforge\/minecraft\/Install\/libraries\/com\/github\/oshi\/oshi-core\/6.4.10\/oshi-core-6.4.10.jar!\/oshi.architecture.properties, jar:file:\/home\/paulv\/Documents\/curseforge\/minecraft\/Install\/libraries\/com\/github\/oshi\/oshi-core\/6.4.10\/oshi-core-6.4.10.jar!\/oshi.architecture.properties]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:56:58] [Datafixer Bootstrap\/INFO]:",
+            "lines": [
+                {
+                    "number": 33,
+                    "content": "[16:56:58] [Datafixer Bootstrap\/INFO]: 237 Datafixer optimizations took 252 milliseconds"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:03] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 34,
+                    "content": "[16:57:03] [Render thread\/INFO]: Environment: Environment[sessionHost=https:\/\/sessionserver.mojang.com, servicesHost=https:\/\/api.minecraftservices.com, name=PROD]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:03] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 35,
+                    "content": "[16:57:03] [Render thread\/INFO]: Setting user: Aternos"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:03] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 36,
+                    "content": "[16:57:03] [Render thread\/INFO]: Backend library: LWJGL version 3.3.3+5"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:03] [modloading-worker-0\/INFO]:",
+            "lines": [
+                {
+                    "number": 37,
+                    "content": "[16:57:03] [modloading-worker-0\/INFO]: Forge mod loading, version 53.0.7, for MC 1.21.3 with MCP 20241025.112443"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:03] [modloading-worker-0\/INFO]:",
+            "lines": [
+                {
+                    "number": 38,
+                    "content": "[16:57:03] [modloading-worker-0\/INFO]: MinecraftForge v53.0.7 Initialized"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:03] [modloading-worker-0\/INFO]:",
+            "lines": [
+                {
+                    "number": 39,
+                    "content": "[16:57:03] [modloading-worker-0\/INFO]: Opening jdk.naming.dns\/com.sun.jndi.dns to java.naming"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:04] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 40,
+                    "content": "[16:57:04] [Render thread\/INFO]: Reloading ResourceManager: vanilla, mod_resources"
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[16:57:04] [modloading-worker-0\/WARN]:",
+            "lines": [
+                {
+                    "number": 41,
+                    "content": "[16:57:04] [modloading-worker-0\/WARN]: Configuration file \/home\/paulv\/Documents\/curseforge\/minecraft\/Instances\/Forge 1.21.3\/config\/forge-client.toml is not correct. Correcting"
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[16:57:04] [modloading-worker-0\/WARN]:",
+            "lines": [
+                {
+                    "number": 42,
+                    "content": "[16:57:04] [modloading-worker-0\/WARN]: Incorrect key client was corrected from null to its default, SynchronizedConfig{DataHolder:{}}. "
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[16:57:04] [modloading-worker-0\/WARN]:",
+            "lines": [
+                {
+                    "number": 43,
+                    "content": "[16:57:04] [modloading-worker-0\/WARN]: Incorrect key client.experimentalForgeLightPipelineEnabled was corrected from null to its default, false. "
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[16:57:04] [modloading-worker-0\/WARN]:",
+            "lines": [
+                {
+                    "number": 44,
+                    "content": "[16:57:04] [modloading-worker-0\/WARN]: Incorrect key client.showLoadWarnings was corrected from null to its default, true. "
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[16:57:04] [modloading-worker-0\/WARN]:",
+            "lines": [
+                {
+                    "number": 45,
+                    "content": "[16:57:04] [modloading-worker-0\/WARN]: Configuration file \/home\/paulv\/Documents\/curseforge\/minecraft\/Instances\/Forge 1.21.3\/config\/forge-common.toml is not correct. Correcting"
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[16:57:04] [modloading-worker-0\/WARN]:",
+            "lines": [
+                {
+                    "number": 46,
+                    "content": "[16:57:04] [modloading-worker-0\/WARN]: Incorrect key general was corrected from null to its default, SynchronizedConfig{DataHolder:{}}. "
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[16:57:04] [modloading-worker-0\/WARN]:",
+            "lines": [
+                {
+                    "number": 47,
+                    "content": "[16:57:04] [modloading-worker-0\/WARN]: Incorrect key general.logLegacyTagWarnings was corrected from null to its default, OFF. "
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:04] [Worker-Main-8\/INFO]:",
+            "lines": [
+                {
+                    "number": 48,
+                    "content": "[16:57:04] [Worker-Main-8\/INFO]: Found unifont_all_no_pua-15.1.05.hex, loading"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:04] [Worker-Main-3\/INFO]:",
+            "lines": [
+                {
+                    "number": 49,
+                    "content": "[16:57:04] [Worker-Main-3\/INFO]: Found unifont_jp_patch-15.1.05.hex, loading"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:04] [Forge Version Check\/INFO]:",
+            "lines": [
+                {
+                    "number": 50,
+                    "content": "[16:57:04] [Forge Version Check\/INFO]: [forge] Starting version check at https:\/\/files.minecraftforge.net\/net\/minecraftforge\/forge\/promotions_slim.json"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:05] [Forge Version Check\/INFO]:",
+            "lines": [
+                {
+                    "number": 51,
+                    "content": "[16:57:05] [Forge Version Check\/INFO]: [forge] Found status: BETA Current: 53.0.7 Target: 53.0.7"
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[16:57:05] [Worker-Main-15\/WARN]:",
+            "lines": [
+                {
+                    "number": 52,
+                    "content": "[16:57:05] [Worker-Main-15\/WARN]: Missing textures in model forge:bucket_milk#inventory:"
+                },
+                {
+                    "number": 53,
+                    "content": "    minecraft:textures\/atlas\/blocks.png:forge:items\/bucket_base"
+                },
+                {
+                    "number": 54,
+                    "content": "    minecraft:textures\/atlas\/blocks.png:forge:items\/bucket_cover"
+                },
+                {
+                    "number": 55,
+                    "content": "    minecraft:textures\/atlas\/blocks.png:forge:items\/bucket_fluid"
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[16:57:06] [Render thread\/WARN]:",
+            "lines": [
+                {
+                    "number": 56,
+                    "content": "[16:57:06] [Render thread\/WARN]: Missing sound for event: minecraft:block.spawner.fall"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:06] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 57,
+                    "content": "[16:57:06] [Render thread\/INFO]: OpenAL initialized on device Built-in Audio Analog Stereo"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:06] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 58,
+                    "content": "[16:57:06] [Render thread\/INFO]: Sound engine started"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:06] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 59,
+                    "content": "[16:57:06] [Render thread\/INFO]: Created: 1024x512x4 minecraft:textures\/atlas\/blocks.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:07] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 60,
+                    "content": "[16:57:07] [Render thread\/INFO]: Created: 256x256x4 minecraft:textures\/atlas\/signs.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:07] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 61,
+                    "content": "[16:57:07] [Render thread\/INFO]: Created: 512x512x4 minecraft:textures\/atlas\/shield_patterns.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:07] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 62,
+                    "content": "[16:57:07] [Render thread\/INFO]: Created: 512x512x4 minecraft:textures\/atlas\/banner_patterns.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:07] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 63,
+                    "content": "[16:57:07] [Render thread\/INFO]: Created: 1024x1024x4 minecraft:textures\/atlas\/armor_trims.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:07] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 64,
+                    "content": "[16:57:07] [Render thread\/INFO]: Created: 256x256x4 minecraft:textures\/atlas\/chest.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:07] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 65,
+                    "content": "[16:57:07] [Render thread\/INFO]: Created: 128x64x4 minecraft:textures\/atlas\/decorated_pot.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:07] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 66,
+                    "content": "[16:57:07] [Render thread\/INFO]: Created: 512x256x4 minecraft:textures\/atlas\/shulker_boxes.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:07] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 67,
+                    "content": "[16:57:07] [Render thread\/INFO]: Created: 512x256x4 minecraft:textures\/atlas\/beds.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:07] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 68,
+                    "content": "[16:57:07] [Render thread\/INFO]: Created: 64x64x0 minecraft:textures\/atlas\/map_decorations.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:07] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 69,
+                    "content": "[16:57:07] [Render thread\/INFO]: Created: 512x256x0 minecraft:textures\/atlas\/particles.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:07] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 70,
+                    "content": "[16:57:07] [Render thread\/INFO]: Created: 512x256x0 minecraft:textures\/atlas\/paintings.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:07] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 71,
+                    "content": "[16:57:07] [Render thread\/INFO]: Created: 256x128x0 minecraft:textures\/atlas\/mob_effects.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:57:07] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 72,
+                    "content": "[16:57:07] [Render thread\/INFO]: Created: 1024x512x0 minecraft:textures\/atlas\/gui.png-atlas"
+                }
+            ]
+        }
+    ],
+    "analysis": {
+        "problems": [],
+        "information": []
+    }
+}

--- a/test/data/Vanilla/Forge/forge-1-21-3-client.log
+++ b/test/data/Vanilla/Forge/forge-1-21-3-client.log
@@ -1,0 +1,72 @@
+[16:56:56] [main/INFO]: ModLauncher running: args [--username, Aternos, --version, forge-53.0.7, --gameDir, /home/paulv/Documents/curseforge/minecraft/Instances/Forge 1.21.3, --assetsDir, /home/paulv/Documents/curseforge/minecraft/Install/assets, --assetIndex, 18, --uuid, ac4a2732dd44408b8d4ee0b6de14b2c1, --accessToken, **********, --clientId, H3rxt6E4CfbDHImeBFoaQM3a/SDrPrAWTr5jBeWUTe/PLfFDgBP7ZgIZNg==, --xuid, 2535449932625433, --userType, msa, --versionType, release, --width, 1024, --height, 768, --quickPlayPath, /home/paulv/Documents/curseforge/minecraft/Install/quickPlay/java/1730217414833.json, --launchTarget, forge_client]
+[16:56:56] [main/INFO]: JVM identified as Microsoft OpenJDK 64-Bit Server VM 21.0.3+9-LTS
+[16:56:56] [main/INFO]: ModLauncher 10.2.2 starting: java version 21.0.3 by Microsoft; OS Linux arch amd64 version 5.15.167-1-MANJARO
+[16:56:56] [main/WARN]: Configuration file /home/paulv/Documents/curseforge/minecraft/Instances/Forge 1.21.3/config/fml.toml is not correct. Correcting
+[16:56:56] [main/INFO]: Incorrect key [earlyWindowSkipGLVersions] was corrected from null to []
+[16:56:56] [main/INFO]: Incorrect key [earlyWindowLogHelpMessage] was corrected from null to true
+[16:56:56] [main/INFO]: Incorrect key [earlyWindowSquir] was corrected from null to false
+[16:56:56] [main/INFO]: Incorrect key [earlyWindowShowCPU] was corrected from null to false
+[16:56:56] [main/INFO]: Loading ImmediateWindowProvider fmlearlywindow
+[16:56:56] [main/INFO]: Trying GL version 4.6
+[16:56:56] [main/INFO]: If this message is the only thing at the bottom of your log before a crash, you probably have a driver issue.
+
+Possible solutions:
+A) Make sure Minecraft is set to prefer high performance graphics in the OS and/or driver control panel
+B) Check for driver updates on the graphics brand's website
+C) Try reinstalling your graphics drivers
+D) If still not working after trying all of the above, ask for further help on the Forge forums or Discord
+
+You can safely ignore this message if the game starts up successfully.
+[16:56:56] [main/INFO]: Requested GL version 4.6 got version 4.6
+[16:56:57] [main/INFO]: SpongePowered MIXIN Subsystem Version=0.8.7 Source=jar:file:///home/paulv/Documents/curseforge/minecraft/Install/libraries/org/spongepowered/mixin/0.8.7/mixin-0.8.7.jar!/ Service=ModLauncher Env=CLIENT
+[16:56:57] [EarlyDisplay/INFO]: GL info: Mesa Intel(R) UHD Graphics (TGL GT1) GL version 4.6 (Core Profile) Mesa 24.2.4-arch1.0.1, Intel
+[16:56:57] [main/INFO]: Found mod file forge-1.21.3-53.0.7-client.jar of type MOD with provider net.minecraftforge.fml.loading.moddiscovery.MinecraftLocator@47e4d9d0
+[16:56:57] [main/INFO]: Found mod file forge-1.21.3-53.0.7-universal.jar of type MOD with provider net.minecraftforge.fml.loading.moddiscovery.ClasspathLocator@4beeb0e
+[16:56:57] [main/INFO]: Found mod file javafmllanguage-1.21.3-53.0.7.jar of type LANGPROVIDER with provider net.minecraftforge.fml.loading.moddiscovery.ClasspathLocator@4beeb0e
+[16:56:57] [main/INFO]: Found mod file lowcodelanguage-1.21.3-53.0.7.jar of type LANGPROVIDER with provider net.minecraftforge.fml.loading.moddiscovery.ClasspathLocator@4beeb0e
+[16:56:57] [main/INFO]: Found mod file fmlcore-1.21.3-53.0.7.jar of type LIBRARY with provider net.minecraftforge.fml.loading.moddiscovery.ClasspathLocator@4beeb0e
+[16:56:57] [main/INFO]: Found mod file mclanguage-1.21.3-53.0.7.jar of type LANGPROVIDER with provider net.minecraftforge.fml.loading.moddiscovery.ClasspathLocator@4beeb0e
+[16:56:57] [main/INFO]: No dependencies to load found. Skipping!
+[16:56:57] [main/INFO]: Launching target 'forge_client' with arguments [--version, forge-53.0.7, --gameDir, /home/paulv/Documents/curseforge/minecraft/Instances/Forge 1.21.3, --assetsDir, /home/paulv/Documents/curseforge/minecraft/Install/assets, --uuid, ac4a2732dd44408b8d4ee0b6de14b2c1, --username, Aternos, --assetIndex, 18, --accessToken, **********, --clientId, H3rxt6E4CfbDHImeBFoaQM3a/SDrPrAWTr5jBeWUTe/PLfFDgBP7ZgIZNg==, --xuid, 2535449932625433, --userType, msa, --versionType, release, --width, 1024, --height, 768, --quickPlayPath, /home/paulv/Documents/curseforge/minecraft/Install/quickPlay/java/1730217414833.json]
+[16:56:58] [main/WARN]: Configuration conflict: there is more than one oshi.properties file on the classpath: [jar:file:///home/paulv/Documents/curseforge/minecraft/Install/libraries/com/github/oshi/oshi-core/6.4.10/oshi-core-6.4.10.jar!/oshi.properties, jar:file:/home/paulv/Documents/curseforge/minecraft/Install/libraries/com/github/oshi/oshi-core/6.4.10/oshi-core-6.4.10.jar!/oshi.properties, jar:file:///home/paulv/Documents/curseforge/minecraft/Install/libraries/com/github/oshi/oshi-core/6.4.10/oshi-core-6.4.10.jar!/oshi.properties, jar:file:/home/paulv/Documents/curseforge/minecraft/Install/libraries/com/github/oshi/oshi-core/6.4.10/oshi-core-6.4.10.jar!/oshi.properties]
+[16:56:58] [main/WARN]: Configuration conflict: there is more than one oshi.architecture.properties file on the classpath: [jar:file:///home/paulv/Documents/curseforge/minecraft/Install/libraries/com/github/oshi/oshi-core/6.4.10/oshi-core-6.4.10.jar!/oshi.architecture.properties, jar:file:/home/paulv/Documents/curseforge/minecraft/Install/libraries/com/github/oshi/oshi-core/6.4.10/oshi-core-6.4.10.jar!/oshi.architecture.properties, jar:file:///home/paulv/Documents/curseforge/minecraft/Install/libraries/com/github/oshi/oshi-core/6.4.10/oshi-core-6.4.10.jar!/oshi.architecture.properties, jar:file:/home/paulv/Documents/curseforge/minecraft/Install/libraries/com/github/oshi/oshi-core/6.4.10/oshi-core-6.4.10.jar!/oshi.architecture.properties]
+[16:56:58] [Datafixer Bootstrap/INFO]: 237 Datafixer optimizations took 252 milliseconds
+[16:57:03] [Render thread/INFO]: Environment: Environment[sessionHost=https://sessionserver.mojang.com, servicesHost=https://api.minecraftservices.com, name=PROD]
+[16:57:03] [Render thread/INFO]: Setting user: Aternos
+[16:57:03] [Render thread/INFO]: Backend library: LWJGL version 3.3.3+5
+[16:57:03] [modloading-worker-0/INFO]: Forge mod loading, version 53.0.7, for MC 1.21.3 with MCP 20241025.112443
+[16:57:03] [modloading-worker-0/INFO]: MinecraftForge v53.0.7 Initialized
+[16:57:03] [modloading-worker-0/INFO]: Opening jdk.naming.dns/com.sun.jndi.dns to java.naming
+[16:57:04] [Render thread/INFO]: Reloading ResourceManager: vanilla, mod_resources
+[16:57:04] [modloading-worker-0/WARN]: Configuration file /home/paulv/Documents/curseforge/minecraft/Instances/Forge 1.21.3/config/forge-client.toml is not correct. Correcting
+[16:57:04] [modloading-worker-0/WARN]: Incorrect key client was corrected from null to its default, SynchronizedConfig{DataHolder:{}}. 
+[16:57:04] [modloading-worker-0/WARN]: Incorrect key client.experimentalForgeLightPipelineEnabled was corrected from null to its default, false. 
+[16:57:04] [modloading-worker-0/WARN]: Incorrect key client.showLoadWarnings was corrected from null to its default, true. 
+[16:57:04] [modloading-worker-0/WARN]: Configuration file /home/paulv/Documents/curseforge/minecraft/Instances/Forge 1.21.3/config/forge-common.toml is not correct. Correcting
+[16:57:04] [modloading-worker-0/WARN]: Incorrect key general was corrected from null to its default, SynchronizedConfig{DataHolder:{}}. 
+[16:57:04] [modloading-worker-0/WARN]: Incorrect key general.logLegacyTagWarnings was corrected from null to its default, OFF. 
+[16:57:04] [Worker-Main-8/INFO]: Found unifont_all_no_pua-15.1.05.hex, loading
+[16:57:04] [Worker-Main-3/INFO]: Found unifont_jp_patch-15.1.05.hex, loading
+[16:57:04] [Forge Version Check/INFO]: [forge] Starting version check at https://files.minecraftforge.net/net/minecraftforge/forge/promotions_slim.json
+[16:57:05] [Forge Version Check/INFO]: [forge] Found status: BETA Current: 53.0.7 Target: 53.0.7
+[16:57:05] [Worker-Main-15/WARN]: Missing textures in model forge:bucket_milk#inventory:
+    minecraft:textures/atlas/blocks.png:forge:items/bucket_base
+    minecraft:textures/atlas/blocks.png:forge:items/bucket_cover
+    minecraft:textures/atlas/blocks.png:forge:items/bucket_fluid
+[16:57:06] [Render thread/WARN]: Missing sound for event: minecraft:block.spawner.fall
+[16:57:06] [Render thread/INFO]: OpenAL initialized on device Built-in Audio Analog Stereo
+[16:57:06] [Render thread/INFO]: Sound engine started
+[16:57:06] [Render thread/INFO]: Created: 1024x512x4 minecraft:textures/atlas/blocks.png-atlas
+[16:57:07] [Render thread/INFO]: Created: 256x256x4 minecraft:textures/atlas/signs.png-atlas
+[16:57:07] [Render thread/INFO]: Created: 512x512x4 minecraft:textures/atlas/shield_patterns.png-atlas
+[16:57:07] [Render thread/INFO]: Created: 512x512x4 minecraft:textures/atlas/banner_patterns.png-atlas
+[16:57:07] [Render thread/INFO]: Created: 1024x1024x4 minecraft:textures/atlas/armor_trims.png-atlas
+[16:57:07] [Render thread/INFO]: Created: 256x256x4 minecraft:textures/atlas/chest.png-atlas
+[16:57:07] [Render thread/INFO]: Created: 128x64x4 minecraft:textures/atlas/decorated_pot.png-atlas
+[16:57:07] [Render thread/INFO]: Created: 512x256x4 minecraft:textures/atlas/shulker_boxes.png-atlas
+[16:57:07] [Render thread/INFO]: Created: 512x256x4 minecraft:textures/atlas/beds.png-atlas
+[16:57:07] [Render thread/INFO]: Created: 64x64x0 minecraft:textures/atlas/map_decorations.png-atlas
+[16:57:07] [Render thread/INFO]: Created: 512x256x0 minecraft:textures/atlas/particles.png-atlas
+[16:57:07] [Render thread/INFO]: Created: 512x256x0 minecraft:textures/atlas/paintings.png-atlas
+[16:57:07] [Render thread/INFO]: Created: 256x128x0 minecraft:textures/atlas/mob_effects.png-atlas
+[16:57:07] [Render thread/INFO]: Created: 1024x512x0 minecraft:textures/atlas/gui.png-atlas

--- a/test/data/Vanilla/Forge/forge-1-21-3-server.json
+++ b/test/data/Vanilla/Forge/forge-1-21-3-server.json
@@ -621,6 +621,23 @@
                 "value": "21.0.4"
             },
             {
+                "message": "Minecraft version: 1.21.3",
+                "counter": 2,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[29Oct2024 17:00:31.096] [modloading-worker-0\/INFO] [net.minecraftforge.common.ForgeMod\/FORGEMOD]:",
+                    "lines": [
+                        {
+                            "number": 10,
+                            "content": "[29Oct2024 17:00:31.096] [modloading-worker-0\/INFO] [net.minecraftforge.common.ForgeMod\/FORGEMOD]: Forge mod loading, version 53.0.7, for MC 1.21.3 with MCP 20241025.112443"
+                        }
+                    ]
+                },
+                "label": "Minecraft version",
+                "value": "1.21.3"
+            },
+            {
                 "message": "Forge version: 53.0.7",
                 "counter": 1,
                 "entry": {
@@ -636,23 +653,6 @@
                 },
                 "label": "Forge version",
                 "value": "53.0.7"
-            },
-            {
-                "message": "Minecraft version: 1.21.3",
-                "counter": 1,
-                "entry": {
-                    "level": 6,
-                    "time": null,
-                    "prefix": "[29Oct2024 17:00:34.158] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]:",
-                    "lines": [
-                        {
-                            "number": 19,
-                            "content": "[29Oct2024 17:00:34.158] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]: Starting minecraft server version 1.21.3"
-                        }
-                    ]
-                },
-                "label": "Minecraft version",
-                "value": "1.21.3"
             }
         ]
     }

--- a/test/data/Vanilla/Forge/forge-1-21-3-server.json
+++ b/test/data/Vanilla/Forge/forge-1-21-3-server.json
@@ -1,0 +1,659 @@
+{
+    "id": "forge\/server",
+    "name": "Forge",
+    "type": "Server Log",
+    "version": "1.21.3",
+    "title": "Forge 1.21.3 Server Log",
+    "entries": [
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:24.896] [main\/INFO] [cpw.mods.modlauncher.Launcher\/MODLAUNCHER]:",
+            "lines": [
+                {
+                    "number": 1,
+                    "content": "[29Oct2024 17:00:24.896] [main\/INFO] [cpw.mods.modlauncher.Launcher\/MODLAUNCHER]: ModLauncher running: args [--launchTarget, forge_server, nogui]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:24.897] [main\/INFO] [cpw.mods.modlauncher.Launcher\/MODLAUNCHER]:",
+            "lines": [
+                {
+                    "number": 2,
+                    "content": "[29Oct2024 17:00:24.897] [main\/INFO] [cpw.mods.modlauncher.Launcher\/MODLAUNCHER]: JVM identified as Eclipse Adoptium OpenJDK 64-Bit Server VM 21.0.4+7-LTS"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:24.898] [main\/INFO] [cpw.mods.modlauncher.Launcher\/MODLAUNCHER]:",
+            "lines": [
+                {
+                    "number": 3,
+                    "content": "[29Oct2024 17:00:24.898] [main\/INFO] [cpw.mods.modlauncher.Launcher\/MODLAUNCHER]: ModLauncher 10.2.2 starting: java version 21.0.4 by Eclipse Adoptium; OS Linux arch amd64 version 5.15.0-117-generic"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:24.968] [main\/INFO] [net.minecraftforge.fml.loading.ImmediateWindowHandler\/]:",
+            "lines": [
+                {
+                    "number": 4,
+                    "content": "[29Oct2024 17:00:24.968] [main\/INFO] [net.minecraftforge.fml.loading.ImmediateWindowHandler\/]: ImmediateWindowProvider not loading because launch target is forge_server"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:25.044] [main\/INFO] [mixin\/]:",
+            "lines": [
+                {
+                    "number": 5,
+                    "content": "[29Oct2024 17:00:25.044] [main\/INFO] [mixin\/]: SpongePowered MIXIN Subsystem Version=0.8.7 Source=jar:file:\/\/\/server\/libraries\/org\/spongepowered\/mixin\/0.8.7\/mixin-0.8.7.jar!\/ Service=ModLauncher Env=SERVER"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:25.223] [main\/INFO] [net.minecraftforge.fml.loading.moddiscovery.JarInJarDependencyLocator\/]:",
+            "lines": [
+                {
+                    "number": 6,
+                    "content": "[29Oct2024 17:00:25.223] [main\/INFO] [net.minecraftforge.fml.loading.moddiscovery.JarInJarDependencyLocator\/]: No dependencies to load found. Skipping!"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:25.778] [main\/INFO] [cpw.mods.modlauncher.LaunchServiceHandler\/MODLAUNCHER]:",
+            "lines": [
+                {
+                    "number": 7,
+                    "content": "[29Oct2024 17:00:25.778] [main\/INFO] [cpw.mods.modlauncher.LaunchServiceHandler\/MODLAUNCHER]: Launching target 'forge_server' with arguments [nogui]"
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:25.991] [main\/WARN] [oshi.util.FileUtil\/]:",
+            "lines": [
+                {
+                    "number": 8,
+                    "content": "[29Oct2024 17:00:25.991] [main\/WARN] [oshi.util.FileUtil\/]: Configuration conflict: there is more than one oshi.properties file on the classpath: [jar:file:\/\/\/server\/libraries\/com\/github\/oshi\/oshi-core\/6.4.10\/oshi-core-6.4.10.jar!\/oshi.properties, jar:file:\/server\/libraries\/com\/github\/oshi\/oshi-core\/6.4.10\/oshi-core-6.4.10.jar!\/oshi.properties, jar:file:\/\/\/server\/libraries\/com\/github\/oshi\/oshi-core\/6.4.10\/oshi-core-6.4.10.jar!\/oshi.properties, jar:file:\/server\/libraries\/com\/github\/oshi\/oshi-core\/6.4.10\/oshi-core-6.4.10.jar!\/oshi.properties]"
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:26.243] [main\/WARN] [oshi.util.FileUtil\/]:",
+            "lines": [
+                {
+                    "number": 9,
+                    "content": "[29Oct2024 17:00:26.243] [main\/WARN] [oshi.util.FileUtil\/]: Configuration conflict: there is more than one oshi.architecture.properties file on the classpath: [jar:file:\/\/\/server\/libraries\/com\/github\/oshi\/oshi-core\/6.4.10\/oshi-core-6.4.10.jar!\/oshi.architecture.properties, jar:file:\/server\/libraries\/com\/github\/oshi\/oshi-core\/6.4.10\/oshi-core-6.4.10.jar!\/oshi.architecture.properties, jar:file:\/\/\/server\/libraries\/com\/github\/oshi\/oshi-core\/6.4.10\/oshi-core-6.4.10.jar!\/oshi.architecture.properties, jar:file:\/server\/libraries\/com\/github\/oshi\/oshi-core\/6.4.10\/oshi-core-6.4.10.jar!\/oshi.architecture.properties]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:31.096] [modloading-worker-0\/INFO] [net.minecraftforge.common.ForgeMod\/FORGEMOD]:",
+            "lines": [
+                {
+                    "number": 10,
+                    "content": "[29Oct2024 17:00:31.096] [modloading-worker-0\/INFO] [net.minecraftforge.common.ForgeMod\/FORGEMOD]: Forge mod loading, version 53.0.7, for MC 1.21.3 with MCP 20241025.112443"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:31.096] [modloading-worker-0\/INFO] [net.minecraftforge.common.MinecraftForge\/FORGE]:",
+            "lines": [
+                {
+                    "number": 11,
+                    "content": "[29Oct2024 17:00:31.096] [modloading-worker-0\/INFO] [net.minecraftforge.common.MinecraftForge\/FORGE]: MinecraftForge v53.0.7 Initialized"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:31.104] [modloading-worker-0\/INFO] [net.minecraftforge.common.ForgeMod\/FORGEMOD]:",
+            "lines": [
+                {
+                    "number": 12,
+                    "content": "[29Oct2024 17:00:31.104] [modloading-worker-0\/INFO] [net.minecraftforge.common.ForgeMod\/FORGEMOD]: Opening jdk.naming.dns\/com.sun.jndi.dns to java.naming"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:31.483] [Forge Version Check\/INFO] [net.minecraftforge.fml.VersionChecker\/]:",
+            "lines": [
+                {
+                    "number": 13,
+                    "content": "[29Oct2024 17:00:31.483] [Forge Version Check\/INFO] [net.minecraftforge.fml.VersionChecker\/]: [forge] Starting version check at https:\/\/files.minecraftforge.net\/net\/minecraftforge\/forge\/promotions_slim.json"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:31.728] [Forge Version Check\/INFO] [net.minecraftforge.fml.VersionChecker\/]:",
+            "lines": [
+                {
+                    "number": 14,
+                    "content": "[29Oct2024 17:00:31.728] [Forge Version Check\/INFO] [net.minecraftforge.fml.VersionChecker\/]: [forge] Found status: BETA Current: 53.0.7 Target: 53.0.7"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:32.649] [main\/INFO] [com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService\/]:",
+            "lines": [
+                {
+                    "number": 15,
+                    "content": "[29Oct2024 17:00:32.649] [main\/INFO] [com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService\/]: Environment: Environment[sessionHost=https:\/\/sessionserver.mojang.com, servicesHost=https:\/\/api.minecraftservices.com, name=PROD]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:33.307] [main\/INFO] [net.minecraft.server.Main\/]:",
+            "lines": [
+                {
+                    "number": 16,
+                    "content": "[29Oct2024 17:00:33.307] [main\/INFO] [net.minecraft.server.Main\/]: No existing world data, creating new world"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:33.983] [main\/INFO] [net.minecraft.world.item.crafting.RecipeManager\/]:",
+            "lines": [
+                {
+                    "number": 17,
+                    "content": "[29Oct2024 17:00:33.983] [main\/INFO] [net.minecraft.world.item.crafting.RecipeManager\/]: Loaded 1337 recipes"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:34.000] [main\/INFO] [net.minecraft.advancements.AdvancementTree\/]:",
+            "lines": [
+                {
+                    "number": 18,
+                    "content": "[29Oct2024 17:00:34.000] [main\/INFO] [net.minecraft.advancements.AdvancementTree\/]: Loaded 1448 advancements"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:34.158] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]:",
+            "lines": [
+                {
+                    "number": 19,
+                    "content": "[29Oct2024 17:00:34.158] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]: Starting minecraft server version 1.21.3"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:34.158] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]:",
+            "lines": [
+                {
+                    "number": 20,
+                    "content": "[29Oct2024 17:00:34.158] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]: Loading properties"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:34.158] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]:",
+            "lines": [
+                {
+                    "number": 21,
+                    "content": "[29Oct2024 17:00:34.158] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]: Default game type: SURVIVAL"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:34.158] [Server thread\/INFO] [net.minecraft.server.MinecraftServer\/]:",
+            "lines": [
+                {
+                    "number": 22,
+                    "content": "[29Oct2024 17:00:34.158] [Server thread\/INFO] [net.minecraft.server.MinecraftServer\/]: Generating keypair"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:34.205] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]:",
+            "lines": [
+                {
+                    "number": 23,
+                    "content": "[29Oct2024 17:00:34.205] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]: Starting Minecraft server on *:28391"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:34.244] [Server thread\/INFO] [net.minecraft.server.network.ServerConnectionListener\/]:",
+            "lines": [
+                {
+                    "number": 24,
+                    "content": "[29Oct2024 17:00:34.244] [Server thread\/INFO] [net.minecraft.server.network.ServerConnectionListener\/]: Using epoll channel type"
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:34.336] [Server thread\/WARN] [net.minecraftforge.common.ForgeConfigSpec\/CORE]:",
+            "lines": [
+                {
+                    "number": 25,
+                    "content": "[29Oct2024 17:00:34.336] [Server thread\/WARN] [net.minecraftforge.common.ForgeConfigSpec\/CORE]: Configuration file .\/world\/serverconfig\/forge-server.toml is not correct. Correcting"
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:34.337] [Server thread\/WARN] [net.minecraftforge.common.ForgeConfigSpec\/CORE]:",
+            "lines": [
+                {
+                    "number": 26,
+                    "content": "[29Oct2024 17:00:34.337] [Server thread\/WARN] [net.minecraftforge.common.ForgeConfigSpec\/CORE]: Incorrect key server was corrected from null to its default, SynchronizedConfig{DataHolder:{}}."
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:34.337] [Server thread\/WARN] [net.minecraftforge.common.ForgeConfigSpec\/CORE]:",
+            "lines": [
+                {
+                    "number": 27,
+                    "content": "[29Oct2024 17:00:34.337] [Server thread\/WARN] [net.minecraftforge.common.ForgeConfigSpec\/CORE]: Incorrect key server.removeErroringBlockEntities was corrected from null to its default, false."
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:34.337] [Server thread\/WARN] [net.minecraftforge.common.ForgeConfigSpec\/CORE]:",
+            "lines": [
+                {
+                    "number": 28,
+                    "content": "[29Oct2024 17:00:34.337] [Server thread\/WARN] [net.minecraftforge.common.ForgeConfigSpec\/CORE]: Incorrect key server.removeErroringEntities was corrected from null to its default, false."
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:34.337] [Server thread\/WARN] [net.minecraftforge.common.ForgeConfigSpec\/CORE]:",
+            "lines": [
+                {
+                    "number": 29,
+                    "content": "[29Oct2024 17:00:34.337] [Server thread\/WARN] [net.minecraftforge.common.ForgeConfigSpec\/CORE]: Incorrect key server.fullBoundingBoxLadders was corrected from null to its default, false."
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:34.338] [Server thread\/WARN] [net.minecraftforge.common.ForgeConfigSpec\/CORE]:",
+            "lines": [
+                {
+                    "number": 30,
+                    "content": "[29Oct2024 17:00:34.338] [Server thread\/WARN] [net.minecraftforge.common.ForgeConfigSpec\/CORE]: Incorrect key server.permissionHandler was corrected from null to its default, forge:default_handler."
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:34.338] [Server thread\/WARN] [net.minecraftforge.common.ForgeConfigSpec\/CORE]:",
+            "lines": [
+                {
+                    "number": 31,
+                    "content": "[29Oct2024 17:00:34.338] [Server thread\/WARN] [net.minecraftforge.common.ForgeConfigSpec\/CORE]: Incorrect key server.advertiseDedicatedServerToLan was corrected from null to its default, true."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:34.364] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]:",
+            "lines": [
+                {
+                    "number": 32,
+                    "content": "[29Oct2024 17:00:34.364] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]: Preparing level \"world\""
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:41.916] [Server thread\/INFO] [net.minecraft.server.MinecraftServer\/]:",
+            "lines": [
+                {
+                    "number": 33,
+                    "content": "[29Oct2024 17:00:41.916] [Server thread\/INFO] [net.minecraft.server.MinecraftServer\/]: Preparing start region for dimension minecraft:overworld"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:41.947] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 34,
+                    "content": "[29Oct2024 17:00:41.947] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 2%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:42.517] [Worker-Main-3\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 35,
+                    "content": "[29Oct2024 17:00:42.517] [Worker-Main-3\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 2%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:42.959] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 36,
+                    "content": "[29Oct2024 17:00:42.959] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 2%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:43.427] [Worker-Main-3\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 37,
+                    "content": "[29Oct2024 17:00:43.427] [Worker-Main-3\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 2%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:43.919] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 38,
+                    "content": "[29Oct2024 17:00:43.919] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 18%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:44.422] [Worker-Main-3\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 39,
+                    "content": "[29Oct2024 17:00:44.422] [Worker-Main-3\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 18%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:44.920] [Worker-Main-3\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 40,
+                    "content": "[29Oct2024 17:00:44.920] [Worker-Main-3\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 18%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:45.433] [Worker-Main-3\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 41,
+                    "content": "[29Oct2024 17:00:45.433] [Worker-Main-3\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 18%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:45.933] [Worker-Main-3\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 42,
+                    "content": "[29Oct2024 17:00:45.933] [Worker-Main-3\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 18%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:46.530] [Worker-Main-3\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 43,
+                    "content": "[29Oct2024 17:00:46.530] [Worker-Main-3\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 18%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:46.999] [Worker-Main-3\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 44,
+                    "content": "[29Oct2024 17:00:46.999] [Worker-Main-3\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 18%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:47.420] [Worker-Main-3\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 45,
+                    "content": "[29Oct2024 17:00:47.420] [Worker-Main-3\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 18%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:47.921] [Worker-Main-3\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 46,
+                    "content": "[29Oct2024 17:00:47.921] [Worker-Main-3\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 18%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:48.337] [Server thread\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 47,
+                    "content": "[29Oct2024 17:00:48.337] [Server thread\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Time elapsed: 6420 ms"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:48.337] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]:",
+            "lines": [
+                {
+                    "number": 48,
+                    "content": "[29Oct2024 17:00:48.337] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]: Done (14.004s)! For help, type \"help\""
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:48.337] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]:",
+            "lines": [
+                {
+                    "number": 49,
+                    "content": "[29Oct2024 17:00:48.337] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]: Starting GS4 status listener"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:48.340] [Server thread\/INFO] [net.minecraft.server.rcon.thread.GenericThread\/]:",
+            "lines": [
+                {
+                    "number": 50,
+                    "content": "[29Oct2024 17:00:48.340] [Server thread\/INFO] [net.minecraft.server.rcon.thread.GenericThread\/]: Thread Query Listener started"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:48.340] [Query Listener #1\/INFO] [net.minecraft.server.rcon.thread.QueryThreadGs4\/]:",
+            "lines": [
+                {
+                    "number": 51,
+                    "content": "[29Oct2024 17:00:48.340] [Query Listener #1\/INFO] [net.minecraft.server.rcon.thread.QueryThreadGs4\/]: Query running on 0.0.0.0:9898"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:48.343] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]:",
+            "lines": [
+                {
+                    "number": 52,
+                    "content": "[29Oct2024 17:00:48.343] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]: JMX monitoring enabled"
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:48.348] [LanServerPinger #1\/WARN] [net.minecraft.client.server.LanServerPinger\/]:",
+            "lines": [
+                {
+                    "number": 53,
+                    "content": "[29Oct2024 17:00:48.348] [LanServerPinger #1\/WARN] [net.minecraft.client.server.LanServerPinger\/]: LanServerPinger: Network is unreachable"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 17:00:48.350] [Server thread\/INFO] [net.minecraftforge.server.permission.PermissionAPI\/]:",
+            "lines": [
+                {
+                    "number": 54,
+                    "content": "[29Oct2024 17:00:48.350] [Server thread\/INFO] [net.minecraftforge.server.permission.PermissionAPI\/]: Successfully initialized permission handler forge:default_handler"
+                }
+            ]
+        }
+    ],
+    "analysis": {
+        "problems": [],
+        "information": [
+            {
+                "message": "Java version: 21.0.4",
+                "counter": 1,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[29Oct2024 17:00:24.898] [main\/INFO] [cpw.mods.modlauncher.Launcher\/MODLAUNCHER]:",
+                    "lines": [
+                        {
+                            "number": 3,
+                            "content": "[29Oct2024 17:00:24.898] [main\/INFO] [cpw.mods.modlauncher.Launcher\/MODLAUNCHER]: ModLauncher 10.2.2 starting: java version 21.0.4 by Eclipse Adoptium; OS Linux arch amd64 version 5.15.0-117-generic"
+                        }
+                    ]
+                },
+                "label": "Java version",
+                "value": "21.0.4"
+            },
+            {
+                "message": "Forge version: 53.0.7",
+                "counter": 1,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[29Oct2024 17:00:31.096] [modloading-worker-0\/INFO] [net.minecraftforge.common.MinecraftForge\/FORGE]:",
+                    "lines": [
+                        {
+                            "number": 11,
+                            "content": "[29Oct2024 17:00:31.096] [modloading-worker-0\/INFO] [net.minecraftforge.common.MinecraftForge\/FORGE]: MinecraftForge v53.0.7 Initialized"
+                        }
+                    ]
+                },
+                "label": "Forge version",
+                "value": "53.0.7"
+            },
+            {
+                "message": "Minecraft version: 1.21.3",
+                "counter": 1,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[29Oct2024 17:00:34.158] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]:",
+                    "lines": [
+                        {
+                            "number": 19,
+                            "content": "[29Oct2024 17:00:34.158] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]: Starting minecraft server version 1.21.3"
+                        }
+                    ]
+                },
+                "label": "Minecraft version",
+                "value": "1.21.3"
+            }
+        ]
+    }
+}

--- a/test/data/Vanilla/Forge/forge-1-21-3-server.log
+++ b/test/data/Vanilla/Forge/forge-1-21-3-server.log
@@ -1,0 +1,54 @@
+[29Oct2024 17:00:24.896] [main/INFO] [cpw.mods.modlauncher.Launcher/MODLAUNCHER]: ModLauncher running: args [--launchTarget, forge_server, nogui]
+[29Oct2024 17:00:24.897] [main/INFO] [cpw.mods.modlauncher.Launcher/MODLAUNCHER]: JVM identified as Eclipse Adoptium OpenJDK 64-Bit Server VM 21.0.4+7-LTS
+[29Oct2024 17:00:24.898] [main/INFO] [cpw.mods.modlauncher.Launcher/MODLAUNCHER]: ModLauncher 10.2.2 starting: java version 21.0.4 by Eclipse Adoptium; OS Linux arch amd64 version 5.15.0-117-generic
+[29Oct2024 17:00:24.968] [main/INFO] [net.minecraftforge.fml.loading.ImmediateWindowHandler/]: ImmediateWindowProvider not loading because launch target is forge_server
+[29Oct2024 17:00:25.044] [main/INFO] [mixin/]: SpongePowered MIXIN Subsystem Version=0.8.7 Source=jar:file:///server/libraries/org/spongepowered/mixin/0.8.7/mixin-0.8.7.jar!/ Service=ModLauncher Env=SERVER
+[29Oct2024 17:00:25.223] [main/INFO] [net.minecraftforge.fml.loading.moddiscovery.JarInJarDependencyLocator/]: No dependencies to load found. Skipping!
+[29Oct2024 17:00:25.778] [main/INFO] [cpw.mods.modlauncher.LaunchServiceHandler/MODLAUNCHER]: Launching target 'forge_server' with arguments [nogui]
+[29Oct2024 17:00:25.991] [main/WARN] [oshi.util.FileUtil/]: Configuration conflict: there is more than one oshi.properties file on the classpath: [jar:file:///server/libraries/com/github/oshi/oshi-core/6.4.10/oshi-core-6.4.10.jar!/oshi.properties, jar:file:/server/libraries/com/github/oshi/oshi-core/6.4.10/oshi-core-6.4.10.jar!/oshi.properties, jar:file:///server/libraries/com/github/oshi/oshi-core/6.4.10/oshi-core-6.4.10.jar!/oshi.properties, jar:file:/server/libraries/com/github/oshi/oshi-core/6.4.10/oshi-core-6.4.10.jar!/oshi.properties]
+[29Oct2024 17:00:26.243] [main/WARN] [oshi.util.FileUtil/]: Configuration conflict: there is more than one oshi.architecture.properties file on the classpath: [jar:file:///server/libraries/com/github/oshi/oshi-core/6.4.10/oshi-core-6.4.10.jar!/oshi.architecture.properties, jar:file:/server/libraries/com/github/oshi/oshi-core/6.4.10/oshi-core-6.4.10.jar!/oshi.architecture.properties, jar:file:///server/libraries/com/github/oshi/oshi-core/6.4.10/oshi-core-6.4.10.jar!/oshi.architecture.properties, jar:file:/server/libraries/com/github/oshi/oshi-core/6.4.10/oshi-core-6.4.10.jar!/oshi.architecture.properties]
+[29Oct2024 17:00:31.096] [modloading-worker-0/INFO] [net.minecraftforge.common.ForgeMod/FORGEMOD]: Forge mod loading, version 53.0.7, for MC 1.21.3 with MCP 20241025.112443
+[29Oct2024 17:00:31.096] [modloading-worker-0/INFO] [net.minecraftforge.common.MinecraftForge/FORGE]: MinecraftForge v53.0.7 Initialized
+[29Oct2024 17:00:31.104] [modloading-worker-0/INFO] [net.minecraftforge.common.ForgeMod/FORGEMOD]: Opening jdk.naming.dns/com.sun.jndi.dns to java.naming
+[29Oct2024 17:00:31.483] [Forge Version Check/INFO] [net.minecraftforge.fml.VersionChecker/]: [forge] Starting version check at https://files.minecraftforge.net/net/minecraftforge/forge/promotions_slim.json
+[29Oct2024 17:00:31.728] [Forge Version Check/INFO] [net.minecraftforge.fml.VersionChecker/]: [forge] Found status: BETA Current: 53.0.7 Target: 53.0.7
+[29Oct2024 17:00:32.649] [main/INFO] [com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService/]: Environment: Environment[sessionHost=https://sessionserver.mojang.com, servicesHost=https://api.minecraftservices.com, name=PROD]
+[29Oct2024 17:00:33.307] [main/INFO] [net.minecraft.server.Main/]: No existing world data, creating new world
+[29Oct2024 17:00:33.983] [main/INFO] [net.minecraft.world.item.crafting.RecipeManager/]: Loaded 1337 recipes
+[29Oct2024 17:00:34.000] [main/INFO] [net.minecraft.advancements.AdvancementTree/]: Loaded 1448 advancements
+[29Oct2024 17:00:34.158] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer/]: Starting minecraft server version 1.21.3
+[29Oct2024 17:00:34.158] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer/]: Loading properties
+[29Oct2024 17:00:34.158] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer/]: Default game type: SURVIVAL
+[29Oct2024 17:00:34.158] [Server thread/INFO] [net.minecraft.server.MinecraftServer/]: Generating keypair
+[29Oct2024 17:00:34.205] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer/]: Starting Minecraft server on *:28391
+[29Oct2024 17:00:34.244] [Server thread/INFO] [net.minecraft.server.network.ServerConnectionListener/]: Using epoll channel type
+[29Oct2024 17:00:34.336] [Server thread/WARN] [net.minecraftforge.common.ForgeConfigSpec/CORE]: Configuration file ./world/serverconfig/forge-server.toml is not correct. Correcting
+[29Oct2024 17:00:34.337] [Server thread/WARN] [net.minecraftforge.common.ForgeConfigSpec/CORE]: Incorrect key server was corrected from null to its default, SynchronizedConfig{DataHolder:{}}.
+[29Oct2024 17:00:34.337] [Server thread/WARN] [net.minecraftforge.common.ForgeConfigSpec/CORE]: Incorrect key server.removeErroringBlockEntities was corrected from null to its default, false.
+[29Oct2024 17:00:34.337] [Server thread/WARN] [net.minecraftforge.common.ForgeConfigSpec/CORE]: Incorrect key server.removeErroringEntities was corrected from null to its default, false.
+[29Oct2024 17:00:34.337] [Server thread/WARN] [net.minecraftforge.common.ForgeConfigSpec/CORE]: Incorrect key server.fullBoundingBoxLadders was corrected from null to its default, false.
+[29Oct2024 17:00:34.338] [Server thread/WARN] [net.minecraftforge.common.ForgeConfigSpec/CORE]: Incorrect key server.permissionHandler was corrected from null to its default, forge:default_handler.
+[29Oct2024 17:00:34.338] [Server thread/WARN] [net.minecraftforge.common.ForgeConfigSpec/CORE]: Incorrect key server.advertiseDedicatedServerToLan was corrected from null to its default, true.
+[29Oct2024 17:00:34.364] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer/]: Preparing level "world"
+[29Oct2024 17:00:41.916] [Server thread/INFO] [net.minecraft.server.MinecraftServer/]: Preparing start region for dimension minecraft:overworld
+[29Oct2024 17:00:41.947] [Worker-Main-1/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 2%
+[29Oct2024 17:00:42.517] [Worker-Main-3/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 2%
+[29Oct2024 17:00:42.959] [Worker-Main-1/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 2%
+[29Oct2024 17:00:43.427] [Worker-Main-3/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 2%
+[29Oct2024 17:00:43.919] [Worker-Main-1/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 18%
+[29Oct2024 17:00:44.422] [Worker-Main-3/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 18%
+[29Oct2024 17:00:44.920] [Worker-Main-3/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 18%
+[29Oct2024 17:00:45.433] [Worker-Main-3/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 18%
+[29Oct2024 17:00:45.933] [Worker-Main-3/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 18%
+[29Oct2024 17:00:46.530] [Worker-Main-3/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 18%
+[29Oct2024 17:00:46.999] [Worker-Main-3/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 18%
+[29Oct2024 17:00:47.420] [Worker-Main-3/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 18%
+[29Oct2024 17:00:47.921] [Worker-Main-3/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 18%
+[29Oct2024 17:00:48.337] [Server thread/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Time elapsed: 6420 ms
+[29Oct2024 17:00:48.337] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer/]: Done (14.004s)! For help, type "help"
+[29Oct2024 17:00:48.337] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer/]: Starting GS4 status listener
+[29Oct2024 17:00:48.340] [Server thread/INFO] [net.minecraft.server.rcon.thread.GenericThread/]: Thread Query Listener started
+[29Oct2024 17:00:48.340] [Query Listener #1/INFO] [net.minecraft.server.rcon.thread.QueryThreadGs4/]: Query running on 0.0.0.0:9898
+[29Oct2024 17:00:48.343] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer/]: JMX monitoring enabled
+[29Oct2024 17:00:48.348] [LanServerPinger #1/WARN] [net.minecraft.client.server.LanServerPinger/]: LanServerPinger: Network is unreachable
+[29Oct2024 17:00:48.350] [Server thread/INFO] [net.minecraftforge.server.permission.PermissionAPI/]: Successfully initialized permission handler forge:default_handler

--- a/test/data/Vanilla/Forge/forge-client-1-16-5.json
+++ b/test/data/Vanilla/Forge/forge-client-1-16-5.json
@@ -646,7 +646,7 @@
         "information": [
             {
                 "message": "Minecraft version: 1.16.5",
-                "counter": 1,
+                "counter": 2,
                 "entry": {
                     "level": 6,
                     "time": null,

--- a/test/data/Vanilla/Forge/forge-client-1-19-2.json
+++ b/test/data/Vanilla/Forge/forge-client-1-19-2.json
@@ -572,7 +572,7 @@
         "information": [
             {
                 "message": "Minecraft version: 1.19.2",
-                "counter": 1,
+                "counter": 2,
                 "entry": {
                     "level": 6,
                     "time": null,

--- a/test/data/Vanilla/Forge/forge-loading-stage-error.json
+++ b/test/data/Vanilla/Forge/forge-loading-stage-error.json
@@ -3317,7 +3317,7 @@
         "information": [
             {
                 "message": "Minecraft version: 1.16.5",
-                "counter": 2,
+                "counter": 3,
                 "entry": {
                     "level": 6,
                     "time": null,

--- a/test/data/Vanilla/Forge/forge-mod-fatal-1444.json
+++ b/test/data/Vanilla/Forge/forge-mod-fatal-1444.json
@@ -6057,7 +6057,7 @@
         "information": [
             {
                 "message": "Minecraft version: 1.14.4",
-                "counter": 3,
+                "counter": 4,
                 "entry": {
                     "level": 6,
                     "time": null,

--- a/test/data/Vanilla/Forge/forge-polymc-1-19-2.json
+++ b/test/data/Vanilla/Forge/forge-polymc-1-19-2.json
@@ -1037,7 +1037,7 @@
         "information": [
             {
                 "message": "Minecraft version: 1.19.2",
-                "counter": 1,
+                "counter": 2,
                 "entry": {
                     "level": 6,
                     "time": null,

--- a/test/data/Vanilla/Forge/forge-start-1132.json
+++ b/test/data/Vanilla/Forge/forge-start-1132.json
@@ -803,7 +803,7 @@
         "information": [
             {
                 "message": "Minecraft version: 1.13.2",
-                "counter": 3,
+                "counter": 4,
                 "entry": {
                     "level": 6,
                     "time": null,

--- a/test/data/Vanilla/Forge/forge-start-1161.json
+++ b/test/data/Vanilla/Forge/forge-start-1161.json
@@ -5429,7 +5429,7 @@
         "information": [
             {
                 "message": "Minecraft version: 1.16.1",
-                "counter": 2,
+                "counter": 3,
                 "entry": {
                     "level": 6,
                     "time": null,

--- a/test/data/Vanilla/NeoForge/neoforge-1-21-3-client.json
+++ b/test/data/Vanilla/NeoForge/neoforge-1-21-3-client.json
@@ -1,0 +1,603 @@
+{
+    "id": "neoforge\/client",
+    "name": "NeoForge",
+    "type": "Client Log",
+    "version": "1.21.3",
+    "title": "NeoForge 1.21.3 Client Log",
+    "entries": [
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:54:38] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 1,
+                    "content": "[16:54:38] [main\/INFO]: ModLauncher running: args [--username, Aternos, --version, neoforge-21.3.5-beta, --gameDir, \/home\/paulv\/Documents\/curseforge\/minecraft\/Instances\/NeoForge 1.21.3, --assetsDir, \/home\/paulv\/Documents\/curseforge\/minecraft\/Install\/assets, --assetIndex, 18, --uuid, ac4a2732dd44408b8d4ee0b6de14b2c1, --accessToken, \u2744\u2744\u2744\u2744\u2744\u2744\u2744\u2744, --clientId, H3rxt6E4CfbDHImeBFoaQM3a\/SDrPrAWTr5jBeWUTe\/PLfFDgBP7ZgIZNg==, --xuid, 2535449932625433, --userType, msa, --versionType, release, --width, 1024, --height, 768, --quickPlayPath, \/home\/paulv\/Documents\/curseforge\/minecraft\/Install\/quickPlay\/java\/1730217276753.json, --fml.neoForgeVersion, 21.3.5-beta, --fml.fmlVersion, 4.0.31, --fml.mcVersion, 1.21.3, --fml.neoFormVersion, 20241023.131943, --launchTarget, forgeclient]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:54:38] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 2,
+                    "content": "[16:54:38] [main\/INFO]: JVM identified as Microsoft OpenJDK 64-Bit Server VM 21.0.3+9-LTS"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:54:38] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 3,
+                    "content": "[16:54:38] [main\/INFO]: ModLauncher 11.0.4+main.d2e20e43 starting: java version 21.0.3 by Microsoft; OS Linux arch amd64 version 5.15.167-1-MANJARO"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:54:38] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 4,
+                    "content": "[16:54:38] [main\/INFO]: Loading ImmediateWindowProvider fmlearlywindow"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:54:38] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 5,
+                    "content": "[16:54:38] [main\/INFO]: Trying GL version 4.6"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:54:38] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 6,
+                    "content": "[16:54:38] [main\/INFO]: Requested GL version 4.6 got version 4.6"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:54:38] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 7,
+                    "content": "[16:54:38] [main\/INFO]: SpongePowered MIXIN Subsystem Version=0.8.7 Source=union:\/home\/paulv\/Documents\/curseforge\/minecraft\/Install\/libraries\/net\/fabricmc\/sponge-mixin\/0.15.2+mixin.0.8.7\/sponge-mixin-0.15.2+mixin.0.8.7.jar%23111!\/ Service=ModLauncher Env=CLIENT"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:54:38] [pool-2-thread-1\/INFO]:",
+            "lines": [
+                {
+                    "number": 8,
+                    "content": "[16:54:38] [pool-2-thread-1\/INFO]: GL info: Mesa Intel(R) UHD Graphics (TGL GT1) GL version 4.6 (Core Profile) Mesa 24.2.4-arch1.0.1, Intel"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:54:38] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 9,
+                    "content": "[16:54:38] [main\/INFO]: Found mod file \"client-1.21.3-20241023.131943-srg.jar\" [locator: production client provider +net.neoforged:neoforge:21.3.5-beta:client]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:54:38] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 10,
+                    "content": "[16:54:38] [main\/INFO]: Found mod file \"neoforge-21.3.5-beta-universal.jar\" [locator: PathBasedLocator[name=neoforge, paths=[\/home\/paulv\/Documents\/curseforge\/minecraft\/Install\/libraries\/net\/neoforged\/neoforge\/21.3.5-beta\/neoforge-21.3.5-beta-universal.jar]], reader: mod manifest]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:54:38] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 11,
+                    "content": "[16:54:38] [main\/INFO]: Found 2 dependencies adding them to mods collection"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:54:38] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 12,
+                    "content": "[16:54:38] [main\/INFO]: Found gamelibrary file \"mixinextras-neoforge-0.4.1.jar\" [parent: neoforge-21.3.5-beta-universal.jar, locator: jarinjar, reader: mod manifest]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:54:38] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 13,
+                    "content": "[16:54:38] [main\/INFO]: Found library file \"neoforge-coremods-21.3.5-beta.jar\" [parent: neoforge-21.3.5-beta-universal.jar, locator: jarinjar, reader: mod manifest]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:54:38] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 14,
+                    "content": "[16:54:38] [main\/INFO]:"
+                },
+                {
+                    "number": 15,
+                    "content": "     Mod List:"
+                },
+                {
+                    "number": 16,
+                    "content": "\t\tName Version (Mod Id)"
+                },
+                {
+                    "number": 17,
+                    "content": ""
+                },
+                {
+                    "number": 18,
+                    "content": "\t\tMinecraft 1.21.3 (minecraft)"
+                },
+                {
+                    "number": 19,
+                    "content": "\t\tNeoForge 21.3.5-beta (neoforge)"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:54:39] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 20,
+                    "content": "[16:54:39] [main\/INFO]: Launching target 'forgeclient' with arguments [--version, neoforge-21.3.5-beta, --gameDir, \/home\/paulv\/Documents\/curseforge\/minecraft\/Instances\/NeoForge 1.21.3, --assetsDir, \/home\/paulv\/Documents\/curseforge\/minecraft\/Install\/assets, --uuid, ac4a2732dd44408b8d4ee0b6de14b2c1, --username, Aternos, --assetIndex, 18, --accessToken, \u2744\u2744\u2744\u2744\u2744\u2744\u2744\u2744, --clientId, H3rxt6E4CfbDHImeBFoaQM3a\/SDrPrAWTr5jBeWUTe\/PLfFDgBP7ZgIZNg==, --xuid, 2535449932625433, --userType, msa, --versionType, release, --width, 1024, --height, 768, --quickPlayPath, \/home\/paulv\/Documents\/curseforge\/minecraft\/Install\/quickPlay\/java\/1730217276753.json]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:40.796] [Datafixer Bootstrap\/INFO] [com.mojang.datafixers.DataFixerBuilder\/]:",
+            "lines": [
+                {
+                    "number": 21,
+                    "content": "[29Oct2024 16:54:40.796] [Datafixer Bootstrap\/INFO] [com.mojang.datafixers.DataFixerBuilder\/]: 240 Datafixer optimizations took 257 milliseconds"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:41.074] [pool-6-thread-1\/INFO] [MixinExtras|Service\/]:",
+            "lines": [
+                {
+                    "number": 22,
+                    "content": "[29Oct2024 16:54:41.074] [pool-6-thread-1\/INFO] [MixinExtras|Service\/]: Initializing MixinExtras via com.llamalad7.mixinextras.service.MixinExtrasServiceImpl(version=0.4.1)."
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:44.858] [Render thread\/WARN] [net.minecraft.server.packs.VanillaPackResourcesBuilder\/]:",
+            "lines": [
+                {
+                    "number": 23,
+                    "content": "[29Oct2024 16:54:44.858] [Render thread\/WARN] [net.minecraft.server.packs.VanillaPackResourcesBuilder\/]: Assets URL 'union:\/home\/paulv\/Documents\/curseforge\/minecraft\/Install\/libraries\/net\/minecraft\/client\/1.21.3-20241023.131943\/client-1.21.3-20241023.131943-srg.jar%23193!\/assets\/.mcassetsroot' uses unexpected schema"
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:44.859] [Render thread\/WARN] [net.minecraft.server.packs.VanillaPackResourcesBuilder\/]:",
+            "lines": [
+                {
+                    "number": 24,
+                    "content": "[29Oct2024 16:54:44.859] [Render thread\/WARN] [net.minecraft.server.packs.VanillaPackResourcesBuilder\/]: Assets URL 'union:\/home\/paulv\/Documents\/curseforge\/minecraft\/Install\/libraries\/net\/minecraft\/client\/1.21.3-20241023.131943\/client-1.21.3-20241023.131943-srg.jar%23193!\/data\/.mcassetsroot' uses unexpected schema"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:44.892] [Render thread\/INFO] [com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService\/]:",
+            "lines": [
+                {
+                    "number": 25,
+                    "content": "[29Oct2024 16:54:44.892] [Render thread\/INFO] [com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService\/]: Environment: Environment[sessionHost=https:\/\/sessionserver.mojang.com, servicesHost=https:\/\/api.minecraftservices.com, name=PROD]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:44.901] [Render thread\/INFO] [net.minecraft.client.Minecraft\/]:",
+            "lines": [
+                {
+                    "number": 26,
+                    "content": "[29Oct2024 16:54:44.901] [Render thread\/INFO] [net.minecraft.client.Minecraft\/]: Setting user: Aternos"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:44.969] [Render thread\/INFO] [net.minecraft.client.Minecraft\/]:",
+            "lines": [
+                {
+                    "number": 27,
+                    "content": "[29Oct2024 16:54:44.969] [Render thread\/INFO] [net.minecraft.client.Minecraft\/]: Backend library: LWJGL version 3.3.3+5"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:45.193] [modloading-worker-0\/INFO] [net.neoforged.neoforge.common.NeoForgeMod\/NEOFORGE-MOD]:",
+            "lines": [
+                {
+                    "number": 28,
+                    "content": "[29Oct2024 16:54:45.193] [modloading-worker-0\/INFO] [net.neoforged.neoforge.common.NeoForgeMod\/NEOFORGE-MOD]: NeoForge mod loading, version 21.3.5-beta, for MC 1.21.3"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:45.989] [Render thread\/INFO] [net.minecraft.server.packs.resources.ReloadableResourceManager\/]:",
+            "lines": [
+                {
+                    "number": 29,
+                    "content": "[29Oct2024 16:54:45.989] [Render thread\/INFO] [net.minecraft.server.packs.resources.ReloadableResourceManager\/]: Reloading ResourceManager: vanilla, mod_resources, mod\/neoforge"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:46.053] [Worker-Main-3\/INFO] [net.minecraft.client.gui.font.providers.UnihexProvider\/]:",
+            "lines": [
+                {
+                    "number": 30,
+                    "content": "[29Oct2024 16:54:46.053] [Worker-Main-3\/INFO] [net.minecraft.client.gui.font.providers.UnihexProvider\/]: Found unifont_all_no_pua-15.1.05.hex, loading"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:46.053] [Worker-Main-15\/INFO] [net.minecraft.client.gui.font.providers.UnihexProvider\/]:",
+            "lines": [
+                {
+                    "number": 31,
+                    "content": "[29Oct2024 16:54:46.053] [Worker-Main-15\/INFO] [net.minecraft.client.gui.font.providers.UnihexProvider\/]: Found unifont_jp_patch-15.1.05.hex, loading"
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:47.081] [Worker-Main-12\/WARN] [net.minecraft.client.resources.model.ModelManager\/]:",
+            "lines": [
+                {
+                    "number": 32,
+                    "content": "[29Oct2024 16:54:47.081] [Worker-Main-12\/WARN] [net.minecraft.client.resources.model.ModelManager\/]: Missing textures in model neoforge:bucket_milk#inventory:"
+                },
+                {
+                    "number": 33,
+                    "content": "    minecraft:textures\/atlas\/blocks.png:neoforge:items\/bucket_base"
+                },
+                {
+                    "number": 34,
+                    "content": "    minecraft:textures\/atlas\/blocks.png:neoforge:items\/bucket_cover"
+                },
+                {
+                    "number": 35,
+                    "content": "    minecraft:textures\/atlas\/blocks.png:neoforge:items\/bucket_fluid"
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:47.330] [Render thread\/WARN] [net.minecraft.client.sounds.SoundEngine\/]:",
+            "lines": [
+                {
+                    "number": 36,
+                    "content": "[29Oct2024 16:54:47.330] [Render thread\/WARN] [net.minecraft.client.sounds.SoundEngine\/]: Missing sound for event: minecraft:block.spawner.fall"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:47.419] [Render thread\/INFO] [com.mojang.blaze3d.audio.Library\/]:",
+            "lines": [
+                {
+                    "number": 37,
+                    "content": "[29Oct2024 16:54:47.419] [Render thread\/INFO] [com.mojang.blaze3d.audio.Library\/]: OpenAL initialized on device Built-in Audio Analog Stereo"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:47.420] [Render thread\/INFO] [net.minecraft.client.sounds.SoundEngine\/SOUNDS]:",
+            "lines": [
+                {
+                    "number": 38,
+                    "content": "[29Oct2024 16:54:47.420] [Render thread\/INFO] [net.minecraft.client.sounds.SoundEngine\/SOUNDS]: Sound engine started"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:47.535] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]:",
+            "lines": [
+                {
+                    "number": 39,
+                    "content": "[29Oct2024 16:54:47.535] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]: Created: 1024x512x4 minecraft:textures\/atlas\/blocks.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:47.618] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]:",
+            "lines": [
+                {
+                    "number": 40,
+                    "content": "[29Oct2024 16:54:47.618] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]: Created: 256x256x4 minecraft:textures\/atlas\/signs.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:47.620] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]:",
+            "lines": [
+                {
+                    "number": 41,
+                    "content": "[29Oct2024 16:54:47.620] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]: Created: 512x512x4 minecraft:textures\/atlas\/banner_patterns.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:47.622] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]:",
+            "lines": [
+                {
+                    "number": 42,
+                    "content": "[29Oct2024 16:54:47.622] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]: Created: 512x512x4 minecraft:textures\/atlas\/shield_patterns.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:47.625] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]:",
+            "lines": [
+                {
+                    "number": 43,
+                    "content": "[29Oct2024 16:54:47.625] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]: Created: 1024x1024x4 minecraft:textures\/atlas\/armor_trims.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:47.646] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]:",
+            "lines": [
+                {
+                    "number": 44,
+                    "content": "[29Oct2024 16:54:47.646] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]: Created: 256x256x4 minecraft:textures\/atlas\/chest.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:47.647] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]:",
+            "lines": [
+                {
+                    "number": 45,
+                    "content": "[29Oct2024 16:54:47.647] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]: Created: 128x64x4 minecraft:textures\/atlas\/decorated_pot.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:47.648] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]:",
+            "lines": [
+                {
+                    "number": 46,
+                    "content": "[29Oct2024 16:54:47.648] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]: Created: 512x256x4 minecraft:textures\/atlas\/shulker_boxes.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:47.649] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]:",
+            "lines": [
+                {
+                    "number": 47,
+                    "content": "[29Oct2024 16:54:47.649] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]: Created: 512x256x4 minecraft:textures\/atlas\/beds.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:47.721] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]:",
+            "lines": [
+                {
+                    "number": 48,
+                    "content": "[29Oct2024 16:54:47.721] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]: Created: 64x64x0 minecraft:textures\/atlas\/map_decorations.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:47.809] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]:",
+            "lines": [
+                {
+                    "number": 49,
+                    "content": "[29Oct2024 16:54:47.809] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]: Created: 512x256x0 minecraft:textures\/atlas\/particles.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:47.813] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]:",
+            "lines": [
+                {
+                    "number": 50,
+                    "content": "[29Oct2024 16:54:47.813] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]: Created: 512x256x0 minecraft:textures\/atlas\/paintings.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:47.814] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]:",
+            "lines": [
+                {
+                    "number": 51,
+                    "content": "[29Oct2024 16:54:47.814] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]: Created: 256x128x0 minecraft:textures\/atlas\/mob_effects.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:47.815] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]:",
+            "lines": [
+                {
+                    "number": 52,
+                    "content": "[29Oct2024 16:54:47.815] [Render thread\/INFO] [net.minecraft.client.renderer.texture.TextureAtlas\/]: Created: 1024x512x0 minecraft:textures\/atlas\/gui.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:47.822] [Render thread\/INFO] [net.neoforged.neoforge.client.entity.animation.json.AnimationLoader\/]:",
+            "lines": [
+                {
+                    "number": 53,
+                    "content": "[29Oct2024 16:54:47.822] [Render thread\/INFO] [net.neoforged.neoforge.client.entity.animation.json.AnimationLoader\/]: Loaded 0 entity animations"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:54:55.642] [Render thread\/INFO] [net.minecraft.client.Minecraft\/]:",
+            "lines": [
+                {
+                    "number": 54,
+                    "content": "[29Oct2024 16:54:55.642] [Render thread\/INFO] [net.minecraft.client.Minecraft\/]: Stopping!"
+                }
+            ]
+        }
+    ],
+    "analysis": {
+        "problems": [],
+        "information": [
+            {
+                "message": "Minecraft version: 1.21.3",
+                "counter": 2,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[16:54:38] [main\/INFO]:",
+                    "lines": [
+                        {
+                            "number": 1,
+                            "content": "[16:54:38] [main\/INFO]: ModLauncher running: args [--username, Aternos, --version, neoforge-21.3.5-beta, --gameDir, \/home\/paulv\/Documents\/curseforge\/minecraft\/Instances\/NeoForge 1.21.3, --assetsDir, \/home\/paulv\/Documents\/curseforge\/minecraft\/Install\/assets, --assetIndex, 18, --uuid, ac4a2732dd44408b8d4ee0b6de14b2c1, --accessToken, \u2744\u2744\u2744\u2744\u2744\u2744\u2744\u2744, --clientId, H3rxt6E4CfbDHImeBFoaQM3a\/SDrPrAWTr5jBeWUTe\/PLfFDgBP7ZgIZNg==, --xuid, 2535449932625433, --userType, msa, --versionType, release, --width, 1024, --height, 768, --quickPlayPath, \/home\/paulv\/Documents\/curseforge\/minecraft\/Install\/quickPlay\/java\/1730217276753.json, --fml.neoForgeVersion, 21.3.5-beta, --fml.fmlVersion, 4.0.31, --fml.mcVersion, 1.21.3, --fml.neoFormVersion, 20241023.131943, --launchTarget, forgeclient]"
+                        }
+                    ]
+                },
+                "label": "Minecraft version",
+                "value": "1.21.3"
+            },
+            {
+                "message": "NeoForge version: 21.3.5-beta",
+                "counter": 2,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[16:54:38] [main\/INFO]:",
+                    "lines": [
+                        {
+                            "number": 1,
+                            "content": "[16:54:38] [main\/INFO]: ModLauncher running: args [--username, Aternos, --version, neoforge-21.3.5-beta, --gameDir, \/home\/paulv\/Documents\/curseforge\/minecraft\/Instances\/NeoForge 1.21.3, --assetsDir, \/home\/paulv\/Documents\/curseforge\/minecraft\/Install\/assets, --assetIndex, 18, --uuid, ac4a2732dd44408b8d4ee0b6de14b2c1, --accessToken, \u2744\u2744\u2744\u2744\u2744\u2744\u2744\u2744, --clientId, H3rxt6E4CfbDHImeBFoaQM3a\/SDrPrAWTr5jBeWUTe\/PLfFDgBP7ZgIZNg==, --xuid, 2535449932625433, --userType, msa, --versionType, release, --width, 1024, --height, 768, --quickPlayPath, \/home\/paulv\/Documents\/curseforge\/minecraft\/Install\/quickPlay\/java\/1730217276753.json, --fml.neoForgeVersion, 21.3.5-beta, --fml.fmlVersion, 4.0.31, --fml.mcVersion, 1.21.3, --fml.neoFormVersion, 20241023.131943, --launchTarget, forgeclient]"
+                        }
+                    ]
+                },
+                "label": "NeoForge version",
+                "value": "21.3.5-beta"
+            },
+            {
+                "message": "Java version: 21.0.3",
+                "counter": 1,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[16:54:38] [main\/INFO]:",
+                    "lines": [
+                        {
+                            "number": 3,
+                            "content": "[16:54:38] [main\/INFO]: ModLauncher 11.0.4+main.d2e20e43 starting: java version 21.0.3 by Microsoft; OS Linux arch amd64 version 5.15.167-1-MANJARO"
+                        }
+                    ]
+                },
+                "label": "Java version",
+                "value": "21.0.3"
+            }
+        ]
+    }
+}

--- a/test/data/Vanilla/NeoForge/neoforge-1-21-3-client.log
+++ b/test/data/Vanilla/NeoForge/neoforge-1-21-3-client.log
@@ -1,0 +1,54 @@
+[16:54:38] [main/INFO]: ModLauncher running: args [--username, Aternos, --version, neoforge-21.3.5-beta, --gameDir, /home/paulv/Documents/curseforge/minecraft/Instances/NeoForge 1.21.3, --assetsDir, /home/paulv/Documents/curseforge/minecraft/Install/assets, --assetIndex, 18, --uuid, ac4a2732dd44408b8d4ee0b6de14b2c1, --accessToken, ❄❄❄❄❄❄❄❄, --clientId, H3rxt6E4CfbDHImeBFoaQM3a/SDrPrAWTr5jBeWUTe/PLfFDgBP7ZgIZNg==, --xuid, 2535449932625433, --userType, msa, --versionType, release, --width, 1024, --height, 768, --quickPlayPath, /home/paulv/Documents/curseforge/minecraft/Install/quickPlay/java/1730217276753.json, --fml.neoForgeVersion, 21.3.5-beta, --fml.fmlVersion, 4.0.31, --fml.mcVersion, 1.21.3, --fml.neoFormVersion, 20241023.131943, --launchTarget, forgeclient]
+[16:54:38] [main/INFO]: JVM identified as Microsoft OpenJDK 64-Bit Server VM 21.0.3+9-LTS
+[16:54:38] [main/INFO]: ModLauncher 11.0.4+main.d2e20e43 starting: java version 21.0.3 by Microsoft; OS Linux arch amd64 version 5.15.167-1-MANJARO
+[16:54:38] [main/INFO]: Loading ImmediateWindowProvider fmlearlywindow
+[16:54:38] [main/INFO]: Trying GL version 4.6
+[16:54:38] [main/INFO]: Requested GL version 4.6 got version 4.6
+[16:54:38] [main/INFO]: SpongePowered MIXIN Subsystem Version=0.8.7 Source=union:/home/paulv/Documents/curseforge/minecraft/Install/libraries/net/fabricmc/sponge-mixin/0.15.2+mixin.0.8.7/sponge-mixin-0.15.2+mixin.0.8.7.jar%23111!/ Service=ModLauncher Env=CLIENT
+[16:54:38] [pool-2-thread-1/INFO]: GL info: Mesa Intel(R) UHD Graphics (TGL GT1) GL version 4.6 (Core Profile) Mesa 24.2.4-arch1.0.1, Intel
+[16:54:38] [main/INFO]: Found mod file "client-1.21.3-20241023.131943-srg.jar" [locator: production client provider +net.neoforged:neoforge:21.3.5-beta:client]
+[16:54:38] [main/INFO]: Found mod file "neoforge-21.3.5-beta-universal.jar" [locator: PathBasedLocator[name=neoforge, paths=[/home/paulv/Documents/curseforge/minecraft/Install/libraries/net/neoforged/neoforge/21.3.5-beta/neoforge-21.3.5-beta-universal.jar]], reader: mod manifest]
+[16:54:38] [main/INFO]: Found 2 dependencies adding them to mods collection
+[16:54:38] [main/INFO]: Found gamelibrary file "mixinextras-neoforge-0.4.1.jar" [parent: neoforge-21.3.5-beta-universal.jar, locator: jarinjar, reader: mod manifest]
+[16:54:38] [main/INFO]: Found library file "neoforge-coremods-21.3.5-beta.jar" [parent: neoforge-21.3.5-beta-universal.jar, locator: jarinjar, reader: mod manifest]
+[16:54:38] [main/INFO]:
+     Mod List:
+		Name Version (Mod Id)
+
+		Minecraft 1.21.3 (minecraft)
+		NeoForge 21.3.5-beta (neoforge)
+[16:54:39] [main/INFO]: Launching target 'forgeclient' with arguments [--version, neoforge-21.3.5-beta, --gameDir, /home/paulv/Documents/curseforge/minecraft/Instances/NeoForge 1.21.3, --assetsDir, /home/paulv/Documents/curseforge/minecraft/Install/assets, --uuid, ac4a2732dd44408b8d4ee0b6de14b2c1, --username, Aternos, --assetIndex, 18, --accessToken, ❄❄❄❄❄❄❄❄, --clientId, H3rxt6E4CfbDHImeBFoaQM3a/SDrPrAWTr5jBeWUTe/PLfFDgBP7ZgIZNg==, --xuid, 2535449932625433, --userType, msa, --versionType, release, --width, 1024, --height, 768, --quickPlayPath, /home/paulv/Documents/curseforge/minecraft/Install/quickPlay/java/1730217276753.json]
+[29Oct2024 16:54:40.796] [Datafixer Bootstrap/INFO] [com.mojang.datafixers.DataFixerBuilder/]: 240 Datafixer optimizations took 257 milliseconds
+[29Oct2024 16:54:41.074] [pool-6-thread-1/INFO] [MixinExtras|Service/]: Initializing MixinExtras via com.llamalad7.mixinextras.service.MixinExtrasServiceImpl(version=0.4.1).
+[29Oct2024 16:54:44.858] [Render thread/WARN] [net.minecraft.server.packs.VanillaPackResourcesBuilder/]: Assets URL 'union:/home/paulv/Documents/curseforge/minecraft/Install/libraries/net/minecraft/client/1.21.3-20241023.131943/client-1.21.3-20241023.131943-srg.jar%23193!/assets/.mcassetsroot' uses unexpected schema
+[29Oct2024 16:54:44.859] [Render thread/WARN] [net.minecraft.server.packs.VanillaPackResourcesBuilder/]: Assets URL 'union:/home/paulv/Documents/curseforge/minecraft/Install/libraries/net/minecraft/client/1.21.3-20241023.131943/client-1.21.3-20241023.131943-srg.jar%23193!/data/.mcassetsroot' uses unexpected schema
+[29Oct2024 16:54:44.892] [Render thread/INFO] [com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService/]: Environment: Environment[sessionHost=https://sessionserver.mojang.com, servicesHost=https://api.minecraftservices.com, name=PROD]
+[29Oct2024 16:54:44.901] [Render thread/INFO] [net.minecraft.client.Minecraft/]: Setting user: Aternos
+[29Oct2024 16:54:44.969] [Render thread/INFO] [net.minecraft.client.Minecraft/]: Backend library: LWJGL version 3.3.3+5
+[29Oct2024 16:54:45.193] [modloading-worker-0/INFO] [net.neoforged.neoforge.common.NeoForgeMod/NEOFORGE-MOD]: NeoForge mod loading, version 21.3.5-beta, for MC 1.21.3
+[29Oct2024 16:54:45.989] [Render thread/INFO] [net.minecraft.server.packs.resources.ReloadableResourceManager/]: Reloading ResourceManager: vanilla, mod_resources, mod/neoforge
+[29Oct2024 16:54:46.053] [Worker-Main-3/INFO] [net.minecraft.client.gui.font.providers.UnihexProvider/]: Found unifont_all_no_pua-15.1.05.hex, loading
+[29Oct2024 16:54:46.053] [Worker-Main-15/INFO] [net.minecraft.client.gui.font.providers.UnihexProvider/]: Found unifont_jp_patch-15.1.05.hex, loading
+[29Oct2024 16:54:47.081] [Worker-Main-12/WARN] [net.minecraft.client.resources.model.ModelManager/]: Missing textures in model neoforge:bucket_milk#inventory:
+    minecraft:textures/atlas/blocks.png:neoforge:items/bucket_base
+    minecraft:textures/atlas/blocks.png:neoforge:items/bucket_cover
+    minecraft:textures/atlas/blocks.png:neoforge:items/bucket_fluid
+[29Oct2024 16:54:47.330] [Render thread/WARN] [net.minecraft.client.sounds.SoundEngine/]: Missing sound for event: minecraft:block.spawner.fall
+[29Oct2024 16:54:47.419] [Render thread/INFO] [com.mojang.blaze3d.audio.Library/]: OpenAL initialized on device Built-in Audio Analog Stereo
+[29Oct2024 16:54:47.420] [Render thread/INFO] [net.minecraft.client.sounds.SoundEngine/SOUNDS]: Sound engine started
+[29Oct2024 16:54:47.535] [Render thread/INFO] [net.minecraft.client.renderer.texture.TextureAtlas/]: Created: 1024x512x4 minecraft:textures/atlas/blocks.png-atlas
+[29Oct2024 16:54:47.618] [Render thread/INFO] [net.minecraft.client.renderer.texture.TextureAtlas/]: Created: 256x256x4 minecraft:textures/atlas/signs.png-atlas
+[29Oct2024 16:54:47.620] [Render thread/INFO] [net.minecraft.client.renderer.texture.TextureAtlas/]: Created: 512x512x4 minecraft:textures/atlas/banner_patterns.png-atlas
+[29Oct2024 16:54:47.622] [Render thread/INFO] [net.minecraft.client.renderer.texture.TextureAtlas/]: Created: 512x512x4 minecraft:textures/atlas/shield_patterns.png-atlas
+[29Oct2024 16:54:47.625] [Render thread/INFO] [net.minecraft.client.renderer.texture.TextureAtlas/]: Created: 1024x1024x4 minecraft:textures/atlas/armor_trims.png-atlas
+[29Oct2024 16:54:47.646] [Render thread/INFO] [net.minecraft.client.renderer.texture.TextureAtlas/]: Created: 256x256x4 minecraft:textures/atlas/chest.png-atlas
+[29Oct2024 16:54:47.647] [Render thread/INFO] [net.minecraft.client.renderer.texture.TextureAtlas/]: Created: 128x64x4 minecraft:textures/atlas/decorated_pot.png-atlas
+[29Oct2024 16:54:47.648] [Render thread/INFO] [net.minecraft.client.renderer.texture.TextureAtlas/]: Created: 512x256x4 minecraft:textures/atlas/shulker_boxes.png-atlas
+[29Oct2024 16:54:47.649] [Render thread/INFO] [net.minecraft.client.renderer.texture.TextureAtlas/]: Created: 512x256x4 minecraft:textures/atlas/beds.png-atlas
+[29Oct2024 16:54:47.721] [Render thread/INFO] [net.minecraft.client.renderer.texture.TextureAtlas/]: Created: 64x64x0 minecraft:textures/atlas/map_decorations.png-atlas
+[29Oct2024 16:54:47.809] [Render thread/INFO] [net.minecraft.client.renderer.texture.TextureAtlas/]: Created: 512x256x0 minecraft:textures/atlas/particles.png-atlas
+[29Oct2024 16:54:47.813] [Render thread/INFO] [net.minecraft.client.renderer.texture.TextureAtlas/]: Created: 512x256x0 minecraft:textures/atlas/paintings.png-atlas
+[29Oct2024 16:54:47.814] [Render thread/INFO] [net.minecraft.client.renderer.texture.TextureAtlas/]: Created: 256x128x0 minecraft:textures/atlas/mob_effects.png-atlas
+[29Oct2024 16:54:47.815] [Render thread/INFO] [net.minecraft.client.renderer.texture.TextureAtlas/]: Created: 1024x512x0 minecraft:textures/atlas/gui.png-atlas
+[29Oct2024 16:54:47.822] [Render thread/INFO] [net.neoforged.neoforge.client.entity.animation.json.AnimationLoader/]: Loaded 0 entity animations
+[29Oct2024 16:54:55.642] [Render thread/INFO] [net.minecraft.client.Minecraft/]: Stopping!

--- a/test/data/Vanilla/NeoForge/neoforge-1-21-3-server.json
+++ b/test/data/Vanilla/NeoForge/neoforge-1-21-3-server.json
@@ -1,0 +1,635 @@
+{
+    "id": "neoforge\/server",
+    "name": "NeoForge",
+    "type": "Server Log",
+    "version": "1.21.3",
+    "title": "NeoForge 1.21.3 Server Log",
+    "entries": [
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:58:54] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 1,
+                    "content": "[16:58:54] [main\/INFO]: ModLauncher running: args [--launchTarget, forgeserver, --fml.neoForgeVersion, 21.3.5-beta, --fml.fmlVersion, 4.0.31, --fml.mcVersion, 1.21.3, --fml.neoFormVersion, 20241023.131943, nogui]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:58:54] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 2,
+                    "content": "[16:58:54] [main\/INFO]: JVM identified as Eclipse Adoptium OpenJDK 64-Bit Server VM 21.0.4+7-LTS"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:58:54] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 3,
+                    "content": "[16:58:54] [main\/INFO]: ModLauncher 11.0.4+main.d2e20e43 starting: java version 21.0.4 by Eclipse Adoptium; OS Linux arch amd64 version 5.15.0-117-generic"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:58:54] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 4,
+                    "content": "[16:58:54] [main\/INFO]: ImmediateWindowProvider not loading because launch target is forgeserver"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:58:54] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 5,
+                    "content": "[16:58:54] [main\/INFO]: SpongePowered MIXIN Subsystem Version=0.8.7 Source=union:\/server\/libraries\/net\/fabricmc\/sponge-mixin\/0.15.2+mixin.0.8.7\/sponge-mixin-0.15.2+mixin.0.8.7.jar%2387!\/ Service=ModLauncher Env=SERVER"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:58:54] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 6,
+                    "content": "[16:58:54] [main\/INFO]: Found mod file \"server-1.21.3-20241023.131943-srg.jar\" [locator: production server provider +net.neoforged:neoforge:21.3.5-beta:server]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:58:54] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 7,
+                    "content": "[16:58:54] [main\/INFO]: Found mod file \"neoforge-21.3.5-beta-universal.jar\" [locator: PathBasedLocator[name=neoforge, paths=[libraries\/net\/neoforged\/neoforge\/21.3.5-beta\/neoforge-21.3.5-beta-universal.jar]], reader: mod manifest]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:58:54] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 8,
+                    "content": "[16:58:54] [main\/INFO]: Found 2 dependencies adding them to mods collection"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:58:54] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 9,
+                    "content": "[16:58:54] [main\/INFO]: Found gamelibrary file \"mixinextras-neoforge-0.4.1.jar\" [parent: neoforge-21.3.5-beta-universal.jar, locator: jarinjar, reader: mod manifest]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:58:54] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 10,
+                    "content": "[16:58:54] [main\/INFO]: Found library file \"neoforge-coremods-21.3.5-beta.jar\" [parent: neoforge-21.3.5-beta-universal.jar, locator: jarinjar, reader: mod manifest]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:58:54] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 11,
+                    "content": "[16:58:54] [main\/INFO]:"
+                },
+                {
+                    "number": 12,
+                    "content": "     Mod List:"
+                },
+                {
+                    "number": 13,
+                    "content": "\t\tName Version (Mod Id)"
+                },
+                {
+                    "number": 14,
+                    "content": ""
+                },
+                {
+                    "number": 15,
+                    "content": "\t\tMinecraft 1.21.3 (minecraft)"
+                },
+                {
+                    "number": 16,
+                    "content": "\t\tNeoForge 21.3.5-beta (neoforge)"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[16:58:55] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 17,
+                    "content": "[16:58:55] [main\/INFO]: Launching target 'forgeserver' with arguments [nogui]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:58:56.603] [main\/INFO] [MixinExtras|Service\/]:",
+            "lines": [
+                {
+                    "number": 18,
+                    "content": "[29Oct2024 16:58:56.603] [main\/INFO] [MixinExtras|Service\/]: Initializing MixinExtras via com.llamalad7.mixinextras.service.MixinExtrasServiceImpl(version=0.4.1)."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:02.109] [modloading-worker-0\/INFO] [net.neoforged.neoforge.common.NeoForgeMod\/NEOFORGE-MOD]:",
+            "lines": [
+                {
+                    "number": 19,
+                    "content": "[29Oct2024 16:59:02.109] [modloading-worker-0\/INFO] [net.neoforged.neoforge.common.NeoForgeMod\/NEOFORGE-MOD]: NeoForge mod loading, version 21.3.5-beta, for MC 1.21.3"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:02.437] [main\/INFO] [com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService\/]:",
+            "lines": [
+                {
+                    "number": 20,
+                    "content": "[29Oct2024 16:59:02.437] [main\/INFO] [com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService\/]: Environment: Environment[sessionHost=https:\/\/sessionserver.mojang.com, servicesHost=https:\/\/api.minecraftservices.com, name=PROD]"
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:02.467] [main\/WARN] [net.minecraft.server.packs.VanillaPackResourcesBuilder\/]:",
+            "lines": [
+                {
+                    "number": 21,
+                    "content": "[29Oct2024 16:59:02.467] [main\/WARN] [net.minecraft.server.packs.VanillaPackResourcesBuilder\/]: Assets URL 'union:\/server\/libraries\/net\/minecraft\/server\/1.21.3-20241023.131943\/server-1.21.3-20241023.131943-srg.jar%23143!\/assets\/.mcassetsroot' uses unexpected schema"
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:02.467] [main\/WARN] [net.minecraft.server.packs.VanillaPackResourcesBuilder\/]:",
+            "lines": [
+                {
+                    "number": 22,
+                    "content": "[29Oct2024 16:59:02.467] [main\/WARN] [net.minecraft.server.packs.VanillaPackResourcesBuilder\/]: Assets URL 'union:\/server\/libraries\/net\/minecraft\/server\/1.21.3-20241023.131943\/server-1.21.3-20241023.131943-srg.jar%23143!\/data\/.mcassetsroot' uses unexpected schema"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:03.357] [main\/INFO] [net.minecraft.server.Main\/]:",
+            "lines": [
+                {
+                    "number": 23,
+                    "content": "[29Oct2024 16:59:03.357] [main\/INFO] [net.minecraft.server.Main\/]: No existing world data, creating new world"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:04.236] [main\/INFO] [net.minecraft.world.item.crafting.RecipeManager\/]:",
+            "lines": [
+                {
+                    "number": 24,
+                    "content": "[29Oct2024 16:59:04.236] [main\/INFO] [net.minecraft.world.item.crafting.RecipeManager\/]: Loaded 1337 recipes"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:04.250] [main\/INFO] [net.minecraft.advancements.AdvancementTree\/]:",
+            "lines": [
+                {
+                    "number": 25,
+                    "content": "[29Oct2024 16:59:04.250] [main\/INFO] [net.minecraft.advancements.AdvancementTree\/]: Loaded 1448 advancements"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:04.379] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]:",
+            "lines": [
+                {
+                    "number": 26,
+                    "content": "[29Oct2024 16:59:04.379] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]: Starting minecraft server version 1.21.3"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:04.380] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]:",
+            "lines": [
+                {
+                    "number": 27,
+                    "content": "[29Oct2024 16:59:04.380] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]: Loading properties"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:04.380] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]:",
+            "lines": [
+                {
+                    "number": 28,
+                    "content": "[29Oct2024 16:59:04.380] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]: Default game type: SURVIVAL"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:04.380] [Server thread\/INFO] [net.minecraft.server.MinecraftServer\/]:",
+            "lines": [
+                {
+                    "number": 29,
+                    "content": "[29Oct2024 16:59:04.380] [Server thread\/INFO] [net.minecraft.server.MinecraftServer\/]: Generating keypair"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:04.632] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]:",
+            "lines": [
+                {
+                    "number": 30,
+                    "content": "[29Oct2024 16:59:04.632] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]: Starting Minecraft server on *:37065"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:04.665] [Server thread\/INFO] [net.minecraft.server.network.ServerConnectionListener\/]:",
+            "lines": [
+                {
+                    "number": 31,
+                    "content": "[29Oct2024 16:59:04.665] [Server thread\/INFO] [net.minecraft.server.network.ServerConnectionListener\/]: Using epoll channel type"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:04.731] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]:",
+            "lines": [
+                {
+                    "number": 32,
+                    "content": "[29Oct2024 16:59:04.731] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]: Preparing level \"world\""
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:15.123] [Server thread\/INFO] [net.minecraft.server.MinecraftServer\/]:",
+            "lines": [
+                {
+                    "number": 33,
+                    "content": "[29Oct2024 16:59:15.123] [Server thread\/INFO] [net.minecraft.server.MinecraftServer\/]: Preparing start region for dimension minecraft:overworld"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:15.209] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 34,
+                    "content": "[29Oct2024 16:59:15.209] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 2%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:15.694] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 35,
+                    "content": "[29Oct2024 16:59:15.694] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 2%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:16.160] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 36,
+                    "content": "[29Oct2024 16:59:16.160] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 2%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:16.635] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 37,
+                    "content": "[29Oct2024 16:59:16.635] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 2%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:17.127] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 38,
+                    "content": "[29Oct2024 16:59:17.127] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 2%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:17.764] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 39,
+                    "content": "[29Oct2024 16:59:17.764] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 2%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:18.277] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 40,
+                    "content": "[29Oct2024 16:59:18.277] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 2%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:18.642] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 41,
+                    "content": "[29Oct2024 16:59:18.642] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 2%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:19.130] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 42,
+                    "content": "[29Oct2024 16:59:19.130] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 2%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:19.642] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 43,
+                    "content": "[29Oct2024 16:59:19.642] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 2%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:20.313] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 44,
+                    "content": "[29Oct2024 16:59:20.313] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 2%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:20.635] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 45,
+                    "content": "[29Oct2024 16:59:20.635] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 2%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:21.242] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 46,
+                    "content": "[29Oct2024 16:59:21.242] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 2%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:21.627] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 47,
+                    "content": "[29Oct2024 16:59:21.627] [Worker-Main-1\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Preparing spawn area: 2%"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:21.942] [Server thread\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]:",
+            "lines": [
+                {
+                    "number": 48,
+                    "content": "[29Oct2024 16:59:21.942] [Server thread\/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener\/]: Time elapsed: 6820 ms"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:21.943] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]:",
+            "lines": [
+                {
+                    "number": 49,
+                    "content": "[29Oct2024 16:59:21.943] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]: Done (17.236s)! For help, type \"help\""
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:21.943] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]:",
+            "lines": [
+                {
+                    "number": 50,
+                    "content": "[29Oct2024 16:59:21.943] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]: Starting GS4 status listener"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:21.945] [Server thread\/INFO] [net.minecraft.server.rcon.thread.GenericThread\/]:",
+            "lines": [
+                {
+                    "number": 51,
+                    "content": "[29Oct2024 16:59:21.945] [Server thread\/INFO] [net.minecraft.server.rcon.thread.GenericThread\/]: Thread Query Listener started"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:21.946] [Query Listener #1\/INFO] [net.minecraft.server.rcon.thread.QueryThreadGs4\/]:",
+            "lines": [
+                {
+                    "number": 52,
+                    "content": "[29Oct2024 16:59:21.946] [Query Listener #1\/INFO] [net.minecraft.server.rcon.thread.QueryThreadGs4\/]: Query running on 0.0.0.0:9898"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:21.948] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]:",
+            "lines": [
+                {
+                    "number": 53,
+                    "content": "[29Oct2024 16:59:21.948] [Server thread\/INFO] [net.minecraft.server.dedicated.DedicatedServer\/]: JMX monitoring enabled"
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:21.954] [LanServerPinger #1\/WARN] [net.minecraft.client.server.LanServerPinger\/]:",
+            "lines": [
+                {
+                    "number": 54,
+                    "content": "[29Oct2024 16:59:21.954] [LanServerPinger #1\/WARN] [net.minecraft.client.server.LanServerPinger\/]: LanServerPinger: Network is unreachable"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[29Oct2024 16:59:21.971] [Server thread\/INFO] [net.neoforged.neoforge.server.permission.PermissionAPI\/]:",
+            "lines": [
+                {
+                    "number": 55,
+                    "content": "[29Oct2024 16:59:21.971] [Server thread\/INFO] [net.neoforged.neoforge.server.permission.PermissionAPI\/]: Successfully initialized permission handler neoforge:default_handler"
+                }
+            ]
+        }
+    ],
+    "analysis": {
+        "problems": [],
+        "information": [
+            {
+                "message": "Minecraft version: 1.21.3",
+                "counter": 3,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[16:58:54] [main\/INFO]:",
+                    "lines": [
+                        {
+                            "number": 1,
+                            "content": "[16:58:54] [main\/INFO]: ModLauncher running: args [--launchTarget, forgeserver, --fml.neoForgeVersion, 21.3.5-beta, --fml.fmlVersion, 4.0.31, --fml.mcVersion, 1.21.3, --fml.neoFormVersion, 20241023.131943, nogui]"
+                        }
+                    ]
+                },
+                "label": "Minecraft version",
+                "value": "1.21.3"
+            },
+            {
+                "message": "NeoForge version: 21.3.5-beta",
+                "counter": 2,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[16:58:54] [main\/INFO]:",
+                    "lines": [
+                        {
+                            "number": 1,
+                            "content": "[16:58:54] [main\/INFO]: ModLauncher running: args [--launchTarget, forgeserver, --fml.neoForgeVersion, 21.3.5-beta, --fml.fmlVersion, 4.0.31, --fml.mcVersion, 1.21.3, --fml.neoFormVersion, 20241023.131943, nogui]"
+                        }
+                    ]
+                },
+                "label": "NeoForge version",
+                "value": "21.3.5-beta"
+            },
+            {
+                "message": "Java version: 21.0.4",
+                "counter": 1,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[16:58:54] [main\/INFO]:",
+                    "lines": [
+                        {
+                            "number": 3,
+                            "content": "[16:58:54] [main\/INFO]: ModLauncher 11.0.4+main.d2e20e43 starting: java version 21.0.4 by Eclipse Adoptium; OS Linux arch amd64 version 5.15.0-117-generic"
+                        }
+                    ]
+                },
+                "label": "Java version",
+                "value": "21.0.4"
+            }
+        ]
+    }
+}

--- a/test/data/Vanilla/NeoForge/neoforge-1-21-3-server.log
+++ b/test/data/Vanilla/NeoForge/neoforge-1-21-3-server.log
@@ -1,0 +1,55 @@
+[16:58:54] [main/INFO]: ModLauncher running: args [--launchTarget, forgeserver, --fml.neoForgeVersion, 21.3.5-beta, --fml.fmlVersion, 4.0.31, --fml.mcVersion, 1.21.3, --fml.neoFormVersion, 20241023.131943, nogui]
+[16:58:54] [main/INFO]: JVM identified as Eclipse Adoptium OpenJDK 64-Bit Server VM 21.0.4+7-LTS
+[16:58:54] [main/INFO]: ModLauncher 11.0.4+main.d2e20e43 starting: java version 21.0.4 by Eclipse Adoptium; OS Linux arch amd64 version 5.15.0-117-generic
+[16:58:54] [main/INFO]: ImmediateWindowProvider not loading because launch target is forgeserver
+[16:58:54] [main/INFO]: SpongePowered MIXIN Subsystem Version=0.8.7 Source=union:/server/libraries/net/fabricmc/sponge-mixin/0.15.2+mixin.0.8.7/sponge-mixin-0.15.2+mixin.0.8.7.jar%2387!/ Service=ModLauncher Env=SERVER
+[16:58:54] [main/INFO]: Found mod file "server-1.21.3-20241023.131943-srg.jar" [locator: production server provider +net.neoforged:neoforge:21.3.5-beta:server]
+[16:58:54] [main/INFO]: Found mod file "neoforge-21.3.5-beta-universal.jar" [locator: PathBasedLocator[name=neoforge, paths=[libraries/net/neoforged/neoforge/21.3.5-beta/neoforge-21.3.5-beta-universal.jar]], reader: mod manifest]
+[16:58:54] [main/INFO]: Found 2 dependencies adding them to mods collection
+[16:58:54] [main/INFO]: Found gamelibrary file "mixinextras-neoforge-0.4.1.jar" [parent: neoforge-21.3.5-beta-universal.jar, locator: jarinjar, reader: mod manifest]
+[16:58:54] [main/INFO]: Found library file "neoforge-coremods-21.3.5-beta.jar" [parent: neoforge-21.3.5-beta-universal.jar, locator: jarinjar, reader: mod manifest]
+[16:58:54] [main/INFO]:
+     Mod List:
+		Name Version (Mod Id)
+
+		Minecraft 1.21.3 (minecraft)
+		NeoForge 21.3.5-beta (neoforge)
+[16:58:55] [main/INFO]: Launching target 'forgeserver' with arguments [nogui]
+[29Oct2024 16:58:56.603] [main/INFO] [MixinExtras|Service/]: Initializing MixinExtras via com.llamalad7.mixinextras.service.MixinExtrasServiceImpl(version=0.4.1).
+[29Oct2024 16:59:02.109] [modloading-worker-0/INFO] [net.neoforged.neoforge.common.NeoForgeMod/NEOFORGE-MOD]: NeoForge mod loading, version 21.3.5-beta, for MC 1.21.3
+[29Oct2024 16:59:02.437] [main/INFO] [com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService/]: Environment: Environment[sessionHost=https://sessionserver.mojang.com, servicesHost=https://api.minecraftservices.com, name=PROD]
+[29Oct2024 16:59:02.467] [main/WARN] [net.minecraft.server.packs.VanillaPackResourcesBuilder/]: Assets URL 'union:/server/libraries/net/minecraft/server/1.21.3-20241023.131943/server-1.21.3-20241023.131943-srg.jar%23143!/assets/.mcassetsroot' uses unexpected schema
+[29Oct2024 16:59:02.467] [main/WARN] [net.minecraft.server.packs.VanillaPackResourcesBuilder/]: Assets URL 'union:/server/libraries/net/minecraft/server/1.21.3-20241023.131943/server-1.21.3-20241023.131943-srg.jar%23143!/data/.mcassetsroot' uses unexpected schema
+[29Oct2024 16:59:03.357] [main/INFO] [net.minecraft.server.Main/]: No existing world data, creating new world
+[29Oct2024 16:59:04.236] [main/INFO] [net.minecraft.world.item.crafting.RecipeManager/]: Loaded 1337 recipes
+[29Oct2024 16:59:04.250] [main/INFO] [net.minecraft.advancements.AdvancementTree/]: Loaded 1448 advancements
+[29Oct2024 16:59:04.379] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer/]: Starting minecraft server version 1.21.3
+[29Oct2024 16:59:04.380] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer/]: Loading properties
+[29Oct2024 16:59:04.380] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer/]: Default game type: SURVIVAL
+[29Oct2024 16:59:04.380] [Server thread/INFO] [net.minecraft.server.MinecraftServer/]: Generating keypair
+[29Oct2024 16:59:04.632] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer/]: Starting Minecraft server on *:37065
+[29Oct2024 16:59:04.665] [Server thread/INFO] [net.minecraft.server.network.ServerConnectionListener/]: Using epoll channel type
+[29Oct2024 16:59:04.731] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer/]: Preparing level "world"
+[29Oct2024 16:59:15.123] [Server thread/INFO] [net.minecraft.server.MinecraftServer/]: Preparing start region for dimension minecraft:overworld
+[29Oct2024 16:59:15.209] [Worker-Main-1/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 2%
+[29Oct2024 16:59:15.694] [Worker-Main-1/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 2%
+[29Oct2024 16:59:16.160] [Worker-Main-1/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 2%
+[29Oct2024 16:59:16.635] [Worker-Main-1/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 2%
+[29Oct2024 16:59:17.127] [Worker-Main-1/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 2%
+[29Oct2024 16:59:17.764] [Worker-Main-1/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 2%
+[29Oct2024 16:59:18.277] [Worker-Main-1/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 2%
+[29Oct2024 16:59:18.642] [Worker-Main-1/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 2%
+[29Oct2024 16:59:19.130] [Worker-Main-1/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 2%
+[29Oct2024 16:59:19.642] [Worker-Main-1/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 2%
+[29Oct2024 16:59:20.313] [Worker-Main-1/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 2%
+[29Oct2024 16:59:20.635] [Worker-Main-1/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 2%
+[29Oct2024 16:59:21.242] [Worker-Main-1/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 2%
+[29Oct2024 16:59:21.627] [Worker-Main-1/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Preparing spawn area: 2%
+[29Oct2024 16:59:21.942] [Server thread/INFO] [net.minecraft.server.level.progress.LoggerChunkProgressListener/]: Time elapsed: 6820 ms
+[29Oct2024 16:59:21.943] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer/]: Done (17.236s)! For help, type "help"
+[29Oct2024 16:59:21.943] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer/]: Starting GS4 status listener
+[29Oct2024 16:59:21.945] [Server thread/INFO] [net.minecraft.server.rcon.thread.GenericThread/]: Thread Query Listener started
+[29Oct2024 16:59:21.946] [Query Listener #1/INFO] [net.minecraft.server.rcon.thread.QueryThreadGs4/]: Query running on 0.0.0.0:9898
+[29Oct2024 16:59:21.948] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer/]: JMX monitoring enabled
+[29Oct2024 16:59:21.954] [LanServerPinger #1/WARN] [net.minecraft.client.server.LanServerPinger/]: LanServerPinger: Network is unreachable
+[29Oct2024 16:59:21.971] [Server thread/INFO] [net.neoforged.neoforge.server.permission.PermissionAPI/]: Successfully initialized permission handler neoforge:default_handler

--- a/test/tests/Logs/AutoLogsTest.php
+++ b/test/tests/Logs/AutoLogsTest.php
@@ -1128,6 +1128,26 @@ class AutoLogsTest extends \PHPUnit\Framework\TestCase
      * @return void
      * @throws Exception
      */
+    public function test_forge_1_21_3_client(): void
+    {
+        $log = new TestLog('Vanilla/Forge/forge-1-21-3-client.log');
+        $this->assertStringEqualsFile($log->getExpectedPath(), $log->getOutput(), $log->getLogPath());
+    }
+
+    /**
+     * @return void
+     * @throws Exception
+     */
+    public function test_forge_1_21_3_server(): void
+    {
+        $log = new TestLog('Vanilla/Forge/forge-1-21-3-server.log');
+        $this->assertStringEqualsFile($log->getExpectedPath(), $log->getOutput(), $log->getLogPath());
+    }
+
+    /**
+     * @return void
+     * @throws Exception
+     */
     public function test_forge_1_7_10_client(): void
     {
         $log = new TestLog('Vanilla/Forge/forge-1-7-10-client.log');
@@ -1531,6 +1551,26 @@ class AutoLogsTest extends \PHPUnit\Framework\TestCase
     public function test_neoforge_1_20_4_server(): void
     {
         $log = new TestLog('Vanilla/NeoForge/neoforge-1-20-4-server.log');
+        $this->assertStringEqualsFile($log->getExpectedPath(), $log->getOutput(), $log->getLogPath());
+    }
+
+    /**
+     * @return void
+     * @throws Exception
+     */
+    public function test_neoforge_1_21_3_client(): void
+    {
+        $log = new TestLog('Vanilla/NeoForge/neoforge-1-21-3-client.log');
+        $this->assertStringEqualsFile($log->getExpectedPath(), $log->getOutput(), $log->getLogPath());
+    }
+
+    /**
+     * @return void
+     * @throws Exception
+     */
+    public function test_neoforge_1_21_3_server(): void
+    {
+        $log = new TestLog('Vanilla/NeoForge/neoforge-1-21-3-server.log');
         $this->assertStringEqualsFile($log->getExpectedPath(), $log->getOutput(), $log->getLogPath());
     }
 


### PR DESCRIPTION
This PR adds a new MultiPatternDetector that recognizes Forge Client logs in newer versions (e.g. 1.21.3). In the newer Forge versions, the log outputs for the Forge version and the environment (target) have been changed.

In addition, a new pattern is added that recognizes the Minecraft version in newer Forge versions. The log output has also been changed...

This PR also adds the latest logs for Forge + NeoForge for 1.21.3 on client and server.