### PR TITLE
Make members for matches not-nullable

### DIFF
--- a/src/Analysis/Problem/Bukkit/AmbiguousPluginNameProblem.php
+++ b/src/Analysis/Problem/Bukkit/AmbiguousPluginNameProblem.php
@@ -13,8 +13,8 @@ use Aternos\Codex\Minecraft\Translator\Translator;
  */
 class AmbiguousPluginNameProblem extends PluginProblem
 {
-    protected ?string $firstPluginPath = null;
-    protected ?string $secondPluginPath = null;
+    protected string $firstPluginPath;
+    protected string $secondPluginPath;
 
     /**
      * Get a human-readable message

--- a/src/Analysis/Problem/Bukkit/PluginCommandExceptionProblem.php
+++ b/src/Analysis/Problem/Bukkit/PluginCommandExceptionProblem.php
@@ -14,7 +14,7 @@ use Aternos\Codex\Minecraft\Translator\Translator;
  */
 class PluginCommandExceptionProblem extends PluginProblem
 {
-    protected ?string $command = null;
+    protected string $command;
 
     /**
      * Get a human-readable message

--- a/src/Analysis/Problem/Bukkit/PluginDependencyProblem.php
+++ b/src/Analysis/Problem/Bukkit/PluginDependencyProblem.php
@@ -13,7 +13,7 @@ use Aternos\Codex\Minecraft\Translator\Translator;
  */
 class PluginDependencyProblem extends PluginFileProblem
 {
-    protected ?string $dependencyPluginName = null;
+    protected string $dependencyPluginName;
 
     /**
      * @return string|null

--- a/src/Analysis/Problem/Bukkit/PluginFileProblem.php
+++ b/src/Analysis/Problem/Bukkit/PluginFileProblem.php
@@ -18,12 +18,12 @@ use Aternos\Codex\Minecraft\Analysis\Solution\File\FileDeleteSolution;
  */
 abstract class PluginFileProblem extends PluginProblem
 {
-    protected ?string $pluginFilePath = null;
+    protected string $pluginFilePath;
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getPluginFilePath(): ?string
+    public function getPluginFilePath(): string
     {
         return $this->pluginFilePath;
     }

--- a/src/Analysis/Problem/Bukkit/PluginProblem.php
+++ b/src/Analysis/Problem/Bukkit/PluginProblem.php
@@ -20,12 +20,12 @@ use Aternos\Codex\Minecraft\Analysis\Solution\Bukkit\PluginRemoveSolution;
  */
 abstract class PluginProblem extends BukkitProblem
 {
-    protected ?string $pluginName = null;
+    protected string $pluginName;
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getPluginName(): ?string
+    public function getPluginName(): string
     {
         return $this->pluginName;
     }

--- a/src/Analysis/Problem/Bukkit/UnsupportedApiVersionProblem.php
+++ b/src/Analysis/Problem/Bukkit/UnsupportedApiVersionProblem.php
@@ -7,12 +7,12 @@ use Aternos\Codex\Minecraft\Translator\Translator;
 
 class UnsupportedApiVersionProblem extends PluginFileProblem
 {
-    protected ?string $apiVersion = null;
+    protected string $apiVersion;
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getApiVersion(): ?string
+    public function getApiVersion(): string
     {
         return $this->apiVersion;
     }

--- a/src/Analysis/Problem/Bukkit/WorldDuplicateProblem.php
+++ b/src/Analysis/Problem/Bukkit/WorldDuplicateProblem.php
@@ -12,12 +12,12 @@ use Aternos\Codex\Minecraft\Translator\Translator;
  */
 class WorldDuplicateProblem extends BukkitProblem
 {
-    protected ?string $worldName = null;
+    protected string $worldName;
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getWorldName(): ?string
+    public function getWorldName(): string
     {
         return $this->worldName;
     }

--- a/src/Analysis/Problem/CrashReport/TickingEntityProblem.php
+++ b/src/Analysis/Problem/CrashReport/TickingEntityProblem.php
@@ -32,7 +32,7 @@ class TickingEntityProblem extends CrashReportProblem
     {
         return Translator::getInstance()->getTranslation("ticking-entity-problem", [
             "name" => $this->getName(),
-            "location" => $this->getLocationX() . ", " . $this->getLocationY() . ", " . $this->getLocationZ()
+            "location" => sprintf("%s, %s, %s", $this->getLocationX(), $this->getLocationY(), $this->getLocationZ())
         ]);
     }
 

--- a/src/Analysis/Problem/Fabric/FabricIncompatibleModsProblem.php
+++ b/src/Analysis/Problem/Fabric/FabricIncompatibleModsProblem.php
@@ -7,7 +7,7 @@ use Aternos\Codex\Minecraft\Translator\Translator;
 
 class FabricIncompatibleModsProblem extends FabricModProblem
 {
-    protected ?string $secondModName = null;
+    protected string $secondModName;
 
     public function getMessage(): string
     {
@@ -18,9 +18,9 @@ class FabricIncompatibleModsProblem extends FabricModProblem
     }
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getSecondModName(): ?string
+    public function getSecondModName(): string
     {
         return $this->secondModName;
     }

--- a/src/Analysis/Problem/Fabric/FabricModProblem.php
+++ b/src/Analysis/Problem/Fabric/FabricModProblem.php
@@ -16,12 +16,12 @@ abstract class FabricModProblem extends FabricProblem
     protected static string $modNamePattern = "(?:'([^\']+)' \((?:[^\)]+)\)|([\w-]+))";
     protected static string $modIDPattern = "([^ ,]+)";
 
-    protected ?string $modName = null;
+    protected string $modName;
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getModName(): ?string
+    public function getModName(): string
     {
         return $this->modName;
     }

--- a/src/Analysis/Problem/Forge/ModDuplicateProblem.php
+++ b/src/Analysis/Problem/Forge/ModDuplicateProblem.php
@@ -13,8 +13,8 @@ use Aternos\Codex\Minecraft\Translator\Translator;
  */
 class ModDuplicateProblem extends ModProblem
 {
-    protected ?string $firstModPath = null;
-    protected ?string $secondModPath = null;
+    protected string $firstModPath;
+    protected string $secondModPath;
 
     /**
      * Get a human-readable message
@@ -78,17 +78,17 @@ class ModDuplicateProblem extends ModProblem
     }
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getFirstModPath(): ?string
+    public function getFirstModPath(): string
     {
         return $this->firstModPath;
     }
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getSecondModPath(): ?string
+    public function getSecondModPath(): string
     {
         return $this->secondModPath;
     }

--- a/src/Analysis/Problem/Forge/ModFatalProblem.php
+++ b/src/Analysis/Problem/Forge/ModFatalProblem.php
@@ -14,9 +14,10 @@ use Aternos\Codex\Minecraft\Translator\Translator;
  */
 class ModFatalProblem extends ModProblem
 {
+    protected string $modId;
+
     protected ?string $modFileName = null;
     protected ?string $modVersion = null;
-    protected ?string $modId = null;
 
     /**
      * Get a human-readable message
@@ -87,9 +88,9 @@ class ModFatalProblem extends ModProblem
     }
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getModId(): ?string
+    public function getModId(): string
     {
         return $this->modId;
     }

--- a/src/Analysis/Problem/Forge/ModProblem.php
+++ b/src/Analysis/Problem/Forge/ModProblem.php
@@ -11,7 +11,7 @@ use Aternos\Codex\Analysis\InsightInterface;
  */
 abstract class ModProblem extends ForgeProblem
 {
-    protected ?string $modName = null;
+    protected string $modName;
 
     /**
      * @return string

--- a/src/Analysis/Problem/Forge/ModWrongMinecraftVersionProblem.php
+++ b/src/Analysis/Problem/Forge/ModWrongMinecraftVersionProblem.php
@@ -13,7 +13,7 @@ use Aternos\Codex\Minecraft\Translator\Translator;
  */
 class ModWrongMinecraftVersionProblem extends ModProblem
 {
-    protected ?string $minecraftVersion = null;
+    protected string $minecraftVersion;
 
     /**
      * @return string

--- a/src/Analysis/Problem/Forge/MultipleModulesExportProblem.php
+++ b/src/Analysis/Problem/Forge/MultipleModulesExportProblem.php
@@ -12,7 +12,7 @@ use Aternos\Codex\Minecraft\Translator\Translator;
  */
 class MultipleModulesExportProblem extends ModProblem
 {
-    protected ?string $secondModName = null;
+    protected string $secondModName;
 
     /**
      * @return string

--- a/src/Analysis/Problem/Forge/WorldModVersionProblem.php
+++ b/src/Analysis/Problem/Forge/WorldModVersionProblem.php
@@ -13,8 +13,8 @@ use Aternos\Codex\Minecraft\Translator\Translator;
  */
 class WorldModVersionProblem extends ModProblem
 {
-    protected ?string $currentVersion = null;
-    protected ?string $expectedVersion = null;
+    protected string $currentVersion;
+    protected string $expectedVersion;
 
     /**
      * Get a human-readable message
@@ -60,17 +60,17 @@ class WorldModVersionProblem extends ModProblem
     }
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getCurrentVersion(): ?string
+    public function getCurrentVersion(): string
     {
         return $this->currentVersion;
     }
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getExpectedVersion(): ?string
+    public function getExpectedVersion(): string
     {
         return $this->expectedVersion;
     }

--- a/src/Analysis/Problem/Paper/ApiVersionLowerThanAllowedProblem.php
+++ b/src/Analysis/Problem/Paper/ApiVersionLowerThanAllowedProblem.php
@@ -13,7 +13,7 @@ use Aternos\Codex\Minecraft\Translator\Translator;
  */
 class ApiVersionLowerThanAllowedProblem extends PluginFileProblem
 {
-    protected ?string $pluginApiVersion = null;
+    protected string $pluginApiVersion;
 
     /**
      * Get a human-readable message
@@ -50,9 +50,9 @@ class ApiVersionLowerThanAllowedProblem extends PluginFileProblem
     }
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getPluginApiVersion(): ?string
+    public function getPluginApiVersion(): string
     {
         return $this->pluginApiVersion;
     }

--- a/src/Analysis/Problem/Pocketmine/PluginDependencyProblem.php
+++ b/src/Analysis/Problem/Pocketmine/PluginDependencyProblem.php
@@ -13,12 +13,12 @@ use Aternos\Codex\Minecraft\Translator\Translator;
  */
 class PluginDependencyProblem extends PluginProblem
 {
-    protected ?string $dependencyPluginName = null;
+    protected string $dependencyPluginName;
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getDependencyPluginName(): ?string
+    public function getDependencyPluginName(): string
     {
         return $this->dependencyPluginName;
     }

--- a/src/Analysis/Problem/Pocketmine/PluginProblem.php
+++ b/src/Analysis/Problem/Pocketmine/PluginProblem.php
@@ -11,12 +11,12 @@ use Aternos\Codex\Analysis\InsightInterface;
  */
 abstract class PluginProblem extends PocketmineProblem
 {
-    protected ?string $pluginName = null;
+    protected string $pluginName;
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getPluginName(): ?string
+    public function getPluginName(): string
     {
         return $this->pluginName;
     }

--- a/src/Analysis/Problem/Pocketmine/PluginRuntimeProblem.php
+++ b/src/Analysis/Problem/Pocketmine/PluginRuntimeProblem.php
@@ -13,7 +13,7 @@ use Aternos\Codex\Minecraft\Translator\Translator;
  */
 class PluginRuntimeProblem extends PluginProblem
 {
-    protected ?string $pluginPath = null;
+    protected string $pluginPath;
 
     /**
      * Get a human-readable message
@@ -50,9 +50,9 @@ class PluginRuntimeProblem extends PluginProblem
     }
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getPluginPath(): ?string
+    public function getPluginPath(): string
     {
         return $this->pluginPath;
     }


### PR DESCRIPTION
All these member variables are always set in `setMatches()`.
This means that they can never be `null` and are not used before set.
We can therefore be sure that they are not nullable and change the types accordingly.