### PR TITLE
Fix detecting fabric client logs from prism launcher

### DIFF
--- a/src/Log/Minecraft/Vanilla/Fabric/FabricClientLog.php
+++ b/src/Log/Minecraft/Vanilla/Fabric/FabricClientLog.php
@@ -14,7 +14,7 @@ class FabricClientLog extends FabricLog implements ClientLogTypeInterface
     {
         return [
             (new MultiPatternDetector())
-                ->addPattern('#^\[[\d:]+\] \[main\/INFO\](?:\:| \(FabricLoader/GameProvider\)) Loading Minecraft [^ \n]+ with Fabric Loader [^ \n]+#')
+                ->addPattern('#^\[[\d:]+\] \[main\/INFO\](?:\:| \(FabricLoader/GameProvider\)) Loading Minecraft [^ \n]+ with Fabric Loader [^ \n]+#m')
                 ->addPattern('#^\[[\d:]+\] \[(?:Render thread|main)\/INFO\](?:\:| \((?:net\.minecraft\.client\.)?Minecraft\)) Setting user: \w+#m')
         ];
     }

--- a/test/data/Vanilla/Fabric/prism-fabric-26-1.json
+++ b/test/data/Vanilla/Fabric/prism-fabric-26-1.json
@@ -1,0 +1,1210 @@
+{
+    "id": "fabric\/client",
+    "name": "Fabric",
+    "type": "Client Log",
+    "version": "26.1",
+    "title": "Fabric 26.1 Client Log",
+    "entries": [
+        {
+            "level": 6,
+            "time": null,
+            "prefix": null,
+            "lines": [
+                {
+                    "number": 1,
+                    "content": "Prism Launcher version: 10.0.5 (official)"
+                },
+                {
+                    "number": 2,
+                    "content": ""
+                },
+                {
+                    "number": 3,
+                    "content": ""
+                },
+                {
+                    "number": 4,
+                    "content": "Launched instance in online mode"
+                },
+                {
+                    "number": 5,
+                    "content": ""
+                },
+                {
+                    "number": 6,
+                    "content": "login.microsoftonline.com resolves to:"
+                },
+                {
+                    "number": 7,
+                    "content": "    [****:****:****:****:****:****:****:****, ****:****:****:****:****:****:****:****, ****:****:****:****:****:****:****:****, ****:****:****:****:****:****:****:****, ****:****:****:****:****:****:****:****, ****:****:****:****:****:****:****:****, ****:****:****:****:****:****:****:****, ****:****:****:****:****:****:****:****, **.**.**.**, **.**.**.**, **.**.**.**, **.**.**.**, **.**.**.**, **.**.**.**, **.**.**.**, **.**.**.**]"
+                },
+                {
+                    "number": 8,
+                    "content": ""
+                },
+                {
+                    "number": 9,
+                    "content": ""
+                },
+                {
+                    "number": 10,
+                    "content": "session.minecraft.net resolves to:"
+                },
+                {
+                    "number": 11,
+                    "content": "    [****:****:****:****:****:****:****:****, **.**.**.**]"
+                },
+                {
+                    "number": 12,
+                    "content": ""
+                },
+                {
+                    "number": 13,
+                    "content": ""
+                },
+                {
+                    "number": 14,
+                    "content": "textures.minecraft.net resolves to:"
+                },
+                {
+                    "number": 15,
+                    "content": "    [****:****:****:****:****:****:****:****, **.**.**.**]"
+                },
+                {
+                    "number": 16,
+                    "content": ""
+                },
+                {
+                    "number": 17,
+                    "content": ""
+                },
+                {
+                    "number": 18,
+                    "content": "api.mojang.com resolves to:"
+                },
+                {
+                    "number": 19,
+                    "content": "    [****:****:****:****:****:****:****:****, **.**.**.**]"
+                },
+                {
+                    "number": 20,
+                    "content": ""
+                },
+                {
+                    "number": 21,
+                    "content": ""
+                },
+                {
+                    "number": 22,
+                    "content": "Minecraft folder is:"
+                },
+                {
+                    "number": 23,
+                    "content": "\/Users\/********\/Library\/Application Support\/PrismLauncher\/instances\/26.1\/minecraft"
+                },
+                {
+                    "number": 24,
+                    "content": ""
+                },
+                {
+                    "number": 25,
+                    "content": ""
+                },
+                {
+                    "number": 26,
+                    "content": "Java path is:"
+                },
+                {
+                    "number": 27,
+                    "content": "\/Users\/********\/Library\/Application Support\/PrismLauncher\/java\/java-runtime-epsilon\/bin\/java"
+                },
+                {
+                    "number": 28,
+                    "content": ""
+                },
+                {
+                    "number": 29,
+                    "content": ""
+                },
+                {
+                    "number": 30,
+                    "content": "Java is version 25.0.1, using 64 (aarch64) architecture, from Microsoft."
+                },
+                {
+                    "number": 31,
+                    "content": ""
+                },
+                {
+                    "number": 32,
+                    "content": ""
+                },
+                {
+                    "number": 33,
+                    "content": "Main Class:"
+                },
+                {
+                    "number": 34,
+                    "content": "  net.fabricmc.loader.impl.launch.knot.KnotClient"
+                },
+                {
+                    "number": 35,
+                    "content": ""
+                },
+                {
+                    "number": 36,
+                    "content": "Native path:"
+                },
+                {
+                    "number": 37,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/instances\/26.1\/natives"
+                },
+                {
+                    "number": 38,
+                    "content": ""
+                },
+                {
+                    "number": 39,
+                    "content": "Traits:"
+                },
+                {
+                    "number": 40,
+                    "content": "traits XR:Initial"
+                },
+                {
+                    "number": 41,
+                    "content": "traits feature:is_quick_play_multiplayer"
+                },
+                {
+                    "number": 42,
+                    "content": "traits feature:is_quick_play_singleplayer"
+                },
+                {
+                    "number": 43,
+                    "content": "traits FirstThreadOnMacOS"
+                },
+                {
+                    "number": 44,
+                    "content": ""
+                },
+                {
+                    "number": 45,
+                    "content": "Libraries:"
+                },
+                {
+                    "number": 46,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/lwjgl\/lwjgl-freetype-natives-macos-arm64\/3.4.1\/lwjgl-freetype-natives-macos-arm64-3.4.1.jar"
+                },
+                {
+                    "number": 47,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/lwjgl\/lwjgl-freetype\/3.4.1\/lwjgl-freetype-3.4.1.jar"
+                },
+                {
+                    "number": 48,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/lwjgl\/lwjgl-glfw-natives-macos-arm64\/3.4.1\/lwjgl-glfw-natives-macos-arm64-3.4.1.jar"
+                },
+                {
+                    "number": 49,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/lwjgl\/lwjgl-glfw\/3.4.1\/lwjgl-glfw-3.4.1.jar"
+                },
+                {
+                    "number": 50,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/lwjgl\/lwjgl-jemalloc-natives-macos-arm64\/3.4.1\/lwjgl-jemalloc-natives-macos-arm64-3.4.1.jar"
+                },
+                {
+                    "number": 51,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/lwjgl\/lwjgl-jemalloc\/3.4.1\/lwjgl-jemalloc-3.4.1.jar"
+                },
+                {
+                    "number": 52,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/lwjgl\/lwjgl-natives-macos-arm64\/3.4.1\/lwjgl-natives-macos-arm64-3.4.1.jar"
+                },
+                {
+                    "number": 53,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/lwjgl\/lwjgl-openal-natives-macos-arm64\/3.4.1\/lwjgl-openal-natives-macos-arm64-3.4.1.jar"
+                },
+                {
+                    "number": 54,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/lwjgl\/lwjgl-openal\/3.4.1\/lwjgl-openal-3.4.1.jar"
+                },
+                {
+                    "number": 55,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/lwjgl\/lwjgl-opengl-natives-macos-arm64\/3.4.1\/lwjgl-opengl-natives-macos-arm64-3.4.1.jar"
+                },
+                {
+                    "number": 56,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/lwjgl\/lwjgl-opengl\/3.4.1\/lwjgl-opengl-3.4.1.jar"
+                },
+                {
+                    "number": 57,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/lwjgl\/lwjgl-stb-natives-macos-arm64\/3.4.1\/lwjgl-stb-natives-macos-arm64-3.4.1.jar"
+                },
+                {
+                    "number": 58,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/lwjgl\/lwjgl-stb\/3.4.1\/lwjgl-stb-3.4.1.jar"
+                },
+                {
+                    "number": 59,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/lwjgl\/lwjgl-tinyfd-natives-macos-arm64\/3.4.1\/lwjgl-tinyfd-natives-macos-arm64-3.4.1.jar"
+                },
+                {
+                    "number": 60,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/lwjgl\/lwjgl-tinyfd\/3.4.1\/lwjgl-tinyfd-3.4.1.jar"
+                },
+                {
+                    "number": 61,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/lwjgl\/lwjgl\/3.4.1\/lwjgl-3.4.1.jar"
+                },
+                {
+                    "number": 62,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/at\/yawk\/lz4\/lz4-java\/1.10.1\/lz4-java-1.10.1.jar"
+                },
+                {
+                    "number": 63,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/ca\/weblite\/java-objc-bridge\/1.1\/java-objc-bridge-1.1.jar"
+                },
+                {
+                    "number": 64,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/com\/azure\/azure-json\/1.4.0\/azure-json-1.4.0.jar"
+                },
+                {
+                    "number": 65,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/com\/github\/oshi\/oshi-core\/6.9.0\/oshi-core-6.9.0.jar"
+                },
+                {
+                    "number": 66,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/com\/google\/code\/gson\/gson\/2.13.2\/gson-2.13.2.jar"
+                },
+                {
+                    "number": 67,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/com\/google\/guava\/failureaccess\/1.0.3\/failureaccess-1.0.3.jar"
+                },
+                {
+                    "number": 68,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/com\/google\/guava\/guava\/33.5.0-jre\/guava-33.5.0-jre.jar"
+                },
+                {
+                    "number": 69,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/com\/ibm\/icu\/icu4j\/77.1\/icu4j-77.1.jar"
+                },
+                {
+                    "number": 70,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/com\/microsoft\/azure\/msal4j\/1.23.1\/msal4j-1.23.1.jar"
+                },
+                {
+                    "number": 71,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/com\/mojang\/authlib\/7.0.63\/authlib-7.0.63.jar"
+                },
+                {
+                    "number": 72,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/com\/mojang\/blocklist\/1.0.10\/blocklist-1.0.10.jar"
+                },
+                {
+                    "number": 73,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/com\/mojang\/brigadier\/1.3.10\/brigadier-1.3.10.jar"
+                },
+                {
+                    "number": 74,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/com\/mojang\/datafixerupper\/9.0.19\/datafixerupper-9.0.19.jar"
+                },
+                {
+                    "number": 75,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/com\/mojang\/jtracy\/1.0.37\/jtracy-1.0.37.jar"
+                },
+                {
+                    "number": 76,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/com\/mojang\/logging\/1.6.11\/logging-1.6.11.jar"
+                },
+                {
+                    "number": 77,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/com\/mojang\/patchy\/2.2.10\/patchy-2.2.10.jar"
+                },
+                {
+                    "number": 78,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/com\/mojang\/text2speech\/1.18.11\/text2speech-1.18.11.jar"
+                },
+                {
+                    "number": 79,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/commons-codec\/commons-codec\/1.19.0\/commons-codec-1.19.0.jar"
+                },
+                {
+                    "number": 80,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/commons-io\/commons-io\/2.20.0\/commons-io-2.20.0.jar"
+                },
+                {
+                    "number": 81,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/io\/netty\/netty-buffer\/4.2.7.Final\/netty-buffer-4.2.7.Final.jar"
+                },
+                {
+                    "number": 82,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/io\/netty\/netty-codec-base\/4.2.7.Final\/netty-codec-base-4.2.7.Final.jar"
+                },
+                {
+                    "number": 83,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/io\/netty\/netty-codec-compression\/4.2.7.Final\/netty-codec-compression-4.2.7.Final.jar"
+                },
+                {
+                    "number": 84,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/io\/netty\/netty-codec-http\/4.2.7.Final\/netty-codec-http-4.2.7.Final.jar"
+                },
+                {
+                    "number": 85,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/io\/netty\/netty-common\/4.2.7.Final\/netty-common-4.2.7.Final.jar"
+                },
+                {
+                    "number": 86,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/io\/netty\/netty-handler\/4.2.7.Final\/netty-handler-4.2.7.Final.jar"
+                },
+                {
+                    "number": 87,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/io\/netty\/netty-resolver\/4.2.7.Final\/netty-resolver-4.2.7.Final.jar"
+                },
+                {
+                    "number": 88,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/io\/netty\/netty-transport-classes-epoll\/4.2.7.Final\/netty-transport-classes-epoll-4.2.7.Final.jar"
+                },
+                {
+                    "number": 89,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/io\/netty\/netty-transport-classes-kqueue\/4.2.7.Final\/netty-transport-classes-kqueue-4.2.7.Final.jar"
+                },
+                {
+                    "number": 90,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/io\/netty\/netty-transport-native-unix-common\/4.2.7.Final\/netty-transport-native-unix-common-4.2.7.Final.jar"
+                },
+                {
+                    "number": 91,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/io\/netty\/netty-transport\/4.2.7.Final\/netty-transport-4.2.7.Final.jar"
+                },
+                {
+                    "number": 92,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/it\/unimi\/dsi\/fastutil\/8.5.18\/fastutil-8.5.18.jar"
+                },
+                {
+                    "number": 93,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/net\/java\/dev\/jna\/jna-platform\/5.17.0\/jna-platform-5.17.0.jar"
+                },
+                {
+                    "number": 94,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/net\/java\/dev\/jna\/jna\/5.17.0\/jna-5.17.0.jar"
+                },
+                {
+                    "number": 95,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/net\/sf\/jopt-simple\/jopt-simple\/5.0.4\/jopt-simple-5.0.4.jar"
+                },
+                {
+                    "number": 96,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/apache\/commons\/commons-compress\/1.28.0\/commons-compress-1.28.0.jar"
+                },
+                {
+                    "number": 97,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/apache\/commons\/commons-lang3\/3.19.0\/commons-lang3-3.19.0.jar"
+                },
+                {
+                    "number": 98,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/apache\/logging\/log4j\/log4j-api\/2.25.2\/log4j-api-2.25.2.jar"
+                },
+                {
+                    "number": 99,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/apache\/logging\/log4j\/log4j-core\/2.25.2\/log4j-core-2.25.2.jar"
+                },
+                {
+                    "number": 100,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/apache\/logging\/log4j\/log4j-slf4j2-impl\/2.25.2\/log4j-slf4j2-impl-2.25.2.jar"
+                },
+                {
+                    "number": 101,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/jcraft\/jorbis\/0.0.17\/jorbis-0.0.17.jar"
+                },
+                {
+                    "number": 102,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/joml\/joml\/1.10.8\/joml-1.10.8.jar"
+                },
+                {
+                    "number": 103,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/jspecify\/jspecify\/1.0.0\/jspecify-1.0.0.jar"
+                },
+                {
+                    "number": 104,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/slf4j\/slf4j-api\/2.0.17\/slf4j-api-2.0.17.jar"
+                },
+                {
+                    "number": 105,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/net\/fabricmc\/intermediary\/26.1\/intermediary-26.1.jar"
+                },
+                {
+                    "number": 106,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/ow2\/asm\/asm\/9.9\/asm-9.9.jar"
+                },
+                {
+                    "number": 107,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/ow2\/asm\/asm-analysis\/9.9\/asm-analysis-9.9.jar"
+                },
+                {
+                    "number": 108,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/ow2\/asm\/asm-commons\/9.9\/asm-commons-9.9.jar"
+                },
+                {
+                    "number": 109,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/ow2\/asm\/asm-tree\/9.9\/asm-tree-9.9.jar"
+                },
+                {
+                    "number": 110,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/ow2\/asm\/asm-util\/9.9\/asm-util-9.9.jar"
+                },
+                {
+                    "number": 111,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/net\/fabricmc\/sponge-mixin\/0.17.0 mixin.0.8.7\/sponge-mixin-0.17.0 mixin.0.8.7.jar"
+                },
+                {
+                    "number": 112,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/net\/fabricmc\/fabric-loader\/0.18.5\/fabric-loader-0.18.5.jar"
+                },
+                {
+                    "number": 113,
+                    "content": "  \/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/com\/mojang\/minecraft\/26.1\/minecraft-26.1-client.jar"
+                },
+                {
+                    "number": 114,
+                    "content": ""
+                },
+                {
+                    "number": 115,
+                    "content": "Native libraries:"
+                },
+                {
+                    "number": 116,
+                    "content": ""
+                },
+                {
+                    "number": 117,
+                    "content": "Params:"
+                },
+                {
+                    "number": 118,
+                    "content": "  --username  --version 26.1 --gameDir \/Users\/********\/Library\/Application Support\/PrismLauncher\/instances\/26.1\/minecraft --assetsDir \/Users\/********\/Library\/Application Support\/PrismLauncher\/assets --assetIndex 30 --uuid  --accessToken  --versionType release"
+                },
+                {
+                    "number": 119,
+                    "content": ""
+                },
+                {
+                    "number": 120,
+                    "content": "Window size: 854 x 480"
+                },
+                {
+                    "number": 121,
+                    "content": ""
+                },
+                {
+                    "number": 122,
+                    "content": "Launcher: standard"
+                },
+                {
+                    "number": 123,
+                    "content": ""
+                },
+                {
+                    "number": 124,
+                    "content": "Java Arguments:"
+                },
+                {
+                    "number": 125,
+                    "content": "[-Xdock:icon=icon.png, -Xdock:name=\"Prism Launcher: 26.1\", -XstartOnFirstThread, -Xms512m, -Xmx8192m, -Duser.language=en]"
+                },
+                {
+                    "number": 126,
+                    "content": ""
+                },
+                {
+                    "number": 127,
+                    "content": ""
+                },
+                {
+                    "number": 128,
+                    "content": "Minecraft process ID: 43959"
+                },
+                {
+                    "number": 129,
+                    "content": ""
+                },
+                {
+                    "number": 130,
+                    "content": ""
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:52] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 131,
+                    "content": "[18:07:52] [main\/INFO]: Loading Minecraft 26.1 with Fabric Loader 0.18.5"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:52] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 132,
+                    "content": "[18:07:52] [main\/INFO]: Loading 4 mods:"
+                },
+                {
+                    "number": 133,
+                    "content": "\t- fabricloader 0.18.5"
+                },
+                {
+                    "number": 134,
+                    "content": "\t   \\-- mixinextras 0.5.3"
+                },
+                {
+                    "number": 135,
+                    "content": "\t- java 25"
+                },
+                {
+                    "number": 136,
+                    "content": "\t- minecraft 26.1"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:52] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 137,
+                    "content": "[18:07:52] [main\/INFO]: SpongePowered MIXIN Subsystem Version=0.8.7 Source=file:\/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/net\/fabricmc\/sponge-mixin\/0.17.0 mixin.0.8.7\/sponge-mixin-0.17.0 mixin.0.8.7.jar Service=Knot\/Fabric Env=CLIENT"
+                },
+                {
+                    "number": 138,
+                    "content": "WARNING: A restricted method in java.lang.System has been called"
+                },
+                {
+                    "number": 139,
+                    "content": "WARNING: java.lang.System::load has been called by com.sun.jna.Native in an unnamed module (file:\/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/net\/java\/dev\/jna\/jna\/5.17.0\/jna-5.17.0.jar)"
+                },
+                {
+                    "number": 140,
+                    "content": "WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module"
+                },
+                {
+                    "number": 141,
+                    "content": "WARNING: Restricted methods will be blocked in a future release unless native access is enabled"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:52] [Datafixer Bootstrap\/INFO]:",
+            "lines": [
+                {
+                    "number": 142,
+                    "content": "[18:07:52] [Datafixer Bootstrap\/INFO]: 291 Datafixer optimizations took 103 milliseconds"
+                },
+                {
+                    "number": 143,
+                    "content": "WARNING: A terminally deprecated method in sun.misc.Unsafe has been called"
+                },
+                {
+                    "number": 144,
+                    "content": "WARNING: sun.misc.Unsafe::objectFieldOffset has been called by org.joml.MemUtil$MemUtilUnsafe (file:\/Users\/********\/Library\/Application Support\/PrismLauncher\/libraries\/org\/joml\/joml\/1.10.8\/joml-1.10.8.jar)"
+                },
+                {
+                    "number": 145,
+                    "content": "WARNING: Please consider reporting this to the maintainers of class org.joml.MemUtil$MemUtilUnsafe"
+                },
+                {
+                    "number": 146,
+                    "content": "WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:54] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 147,
+                    "content": "[18:07:54] [Render thread\/INFO]: Environment: Environment[sessionHost=https:\/\/sessionserver.mojang.com, servicesHost=https:\/\/api.minecraftservices.com, profilesHost=https:\/\/api.mojang.com, name=PROD]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:54] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 148,
+                    "content": "[18:07:54] [Render thread\/INFO]: Setting user: NutellaGolem"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:54] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 149,
+                    "content": "[18:07:54] [Render thread\/INFO]: Backend library: LWJGL version 3.4.1-snapshot"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:55] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 150,
+                    "content": "[18:07:55] [Render thread\/INFO]: Using optional rendering extensions: GL_EXT_texture_filter_anisotropic"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 151,
+                    "content": "[18:07:56] [Render thread\/INFO]: Reloading ResourceManager: vanilla"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Worker-Main-3\/INFO]:",
+            "lines": [
+                {
+                    "number": 152,
+                    "content": "[18:07:56] [Worker-Main-3\/INFO]: Found unifont_all_no_pua-17.0.01.hex, loading"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Worker-Main-6\/INFO]:",
+            "lines": [
+                {
+                    "number": 153,
+                    "content": "[18:07:56] [Worker-Main-6\/INFO]: Found unifont_pua-17.0.01.hex, loading"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Worker-Main-7\/INFO]:",
+            "lines": [
+                {
+                    "number": 154,
+                    "content": "[18:07:56] [Worker-Main-7\/INFO]: Found unifont_jp_patch-17.0.01.hex, loading"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 155,
+                    "content": "[18:07:56] [Render thread\/INFO]: Info log when linking program containing VS minecraft:core\/entity and FS minecraft:core\/entity. Log output: WARNING: Could not find vertex shader attribute 'UV1' to match BindAttributeLocation request."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 156,
+                    "content": "[18:07:56] [Render thread\/INFO]: Info log when linking program containing VS minecraft:core\/entity and FS minecraft:core\/entity. Log output: WARNING: Could not find vertex shader attribute 'UV1' to match BindAttributeLocation request."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 157,
+                    "content": "[18:07:56] [Render thread\/INFO]: Info log when linking program containing VS minecraft:core\/rendertype_text_background_see_through and FS minecraft:core\/rendertype_text_background_see_through. Log output: WARNING: Could not find vertex shader attribute 'UV2' to match BindAttributeLocation request."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 158,
+                    "content": "[18:07:56] [Render thread\/INFO]: Info log when linking program containing VS minecraft:core\/entity and FS minecraft:core\/entity. Log output: WARNING: Could not find vertex shader attribute 'UV1' to match BindAttributeLocation request."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 159,
+                    "content": "[18:07:56] [Render thread\/INFO]: Info log when linking program containing VS minecraft:core\/item and FS minecraft:core\/item. Log output: WARNING: Could not find vertex shader attribute 'UV1' to match BindAttributeLocation request."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 160,
+                    "content": "[18:07:56] [Render thread\/INFO]: Info log when linking program containing VS minecraft:core\/rendertype_beacon_beam and FS minecraft:core\/rendertype_beacon_beam. Log output: WARNING: Could not find vertex shader attribute 'UV2' to match BindAttributeLocation request."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 161,
+                    "content": "[18:07:56] [Render thread\/INFO]: Info log when linking program containing VS minecraft:core\/rendertype_beacon_beam and FS minecraft:core\/rendertype_beacon_beam. Log output: WARNING: Could not find vertex shader attribute 'UV2' to match BindAttributeLocation request."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 162,
+                    "content": "[18:07:56] [Render thread\/INFO]: Info log when linking program containing VS minecraft:core\/entity and FS minecraft:core\/entity. Log output: WARNING: Could not find vertex shader attribute 'UV2' to match BindAttributeLocation request."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 163,
+                    "content": "[18:07:56] [Render thread\/INFO]: Info log when linking program containing VS minecraft:core\/rendertype_text_intensity_see_through and FS minecraft:core\/rendertype_text_intensity_see_through. Log output: WARNING: Could not find vertex shader attribute 'UV2' to match BindAttributeLocation request."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 164,
+                    "content": "[18:07:56] [Render thread\/INFO]: Info log when linking program containing VS minecraft:core\/entity and FS minecraft:core\/entity. Log output: WARNING: Could not find vertex shader attribute 'UV1' to match BindAttributeLocation request."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 165,
+                    "content": "[18:07:56] [Render thread\/INFO]: Info log when linking program containing VS minecraft:core\/entity and FS minecraft:core\/entity. Log output: WARNING: Could not find vertex shader attribute 'UV1' to match BindAttributeLocation request."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 166,
+                    "content": "[18:07:56] [Render thread\/INFO]: Info log when linking program containing VS minecraft:core\/entity and FS minecraft:core\/entity. Log output: WARNING: Could not find vertex shader attribute 'UV1' to match BindAttributeLocation request."
+                },
+                {
+                    "number": 167,
+                    "content": "WARNING: Could not find vertex shader attribute 'Normal' to match BindAttributeLocation request."
+                },
+                {
+                    "number": 168,
+                    "content": "WARNING: Could not find vertex shader attribute 'UV2' to match BindAttributeLocation request."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 169,
+                    "content": "[18:07:56] [Render thread\/INFO]: Info log when linking program containing VS minecraft:core\/animate_sprite and FS minecraft:core\/animate_sprite_blit. Log output: WARNING: Output of vertex shader 'fAnimationProgress' not read by fragment shader"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 170,
+                    "content": "[18:07:56] [Render thread\/INFO]: Info log when linking program containing VS minecraft:core\/rendertype_entity_shadow and FS minecraft:core\/rendertype_entity_shadow. Log output: WARNING: Could not find vertex shader attribute 'UV1' to match BindAttributeLocation request."
+                },
+                {
+                    "number": 171,
+                    "content": "WARNING: Could not find vertex shader attribute 'Normal' to match BindAttributeLocation request."
+                },
+                {
+                    "number": 172,
+                    "content": "WARNING: Could not find vertex shader attribute 'UV2' to match BindAttributeLocation request."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 173,
+                    "content": "[18:07:56] [Render thread\/INFO]: Info log when linking program containing VS minecraft:core\/entity and FS minecraft:core\/entity. Log output: WARNING: Could not find vertex shader attribute 'UV1' to match BindAttributeLocation request."
+                },
+                {
+                    "number": 174,
+                    "content": "WARNING: Could not find vertex shader attribute 'Normal' to match BindAttributeLocation request."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 175,
+                    "content": "[18:07:56] [Render thread\/INFO]: Info log when linking program containing VS minecraft:core\/rendertype_text_see_through and FS minecraft:core\/rendertype_text_see_through. Log output: WARNING: Could not find vertex shader attribute 'UV2' to match BindAttributeLocation request."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 176,
+                    "content": "[18:07:56] [Render thread\/INFO]: Info log when linking program containing VS minecraft:core\/entity and FS minecraft:core\/entity. Log output: WARNING: Could not find vertex shader attribute 'UV1' to match BindAttributeLocation request."
+                },
+                {
+                    "number": 177,
+                    "content": "WARNING: Could not find vertex shader attribute 'Normal' to match BindAttributeLocation request."
+                },
+                {
+                    "number": 178,
+                    "content": "WARNING: Could not find vertex shader attribute 'UV2' to match BindAttributeLocation request."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 179,
+                    "content": "[18:07:56] [Render thread\/INFO]: Info log when linking program containing VS minecraft:core\/item and FS minecraft:core\/item. Log output: WARNING: Could not find vertex shader attribute 'UV1' to match BindAttributeLocation request."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 180,
+                    "content": "[18:07:56] [Render thread\/INFO]: Info log when linking program containing VS minecraft:core\/rendertype_crumbling and FS minecraft:core\/rendertype_crumbling. Log output: WARNING: Could not find vertex shader attribute 'UV2' to match BindAttributeLocation request."
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 181,
+                    "content": "[18:07:56] [Render thread\/INFO]: OpenAL initialized on device MacBook Pro Speakers"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 182,
+                    "content": "[18:07:56] [Render thread\/INFO]: Sound engine started"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 183,
+                    "content": "[18:07:56] [Render thread\/INFO]: Created: 512x256x0 minecraft:textures\/atlas\/particles.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 184,
+                    "content": "[18:07:56] [Render thread\/INFO]: Created: 128x128x0 minecraft:textures\/atlas\/decorated_pot.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 185,
+                    "content": "[18:07:56] [Render thread\/INFO]: Created: 2048x1024x0 minecraft:textures\/atlas\/armor_trims.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 186,
+                    "content": "[18:07:56] [Render thread\/INFO]: Created: 512x256x0 minecraft:textures\/atlas\/paintings.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 187,
+                    "content": "[18:07:56] [Render thread\/INFO]: Created: 1024x512x0 minecraft:textures\/atlas\/shield_patterns.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:56] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 188,
+                    "content": "[18:07:56] [Render thread\/INFO]: Created: 2048x2048x4 minecraft:textures\/atlas\/blocks.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:57] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 189,
+                    "content": "[18:07:57] [Render thread\/INFO]: Created: 512x512x0 minecraft:textures\/atlas\/chest.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:57] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 190,
+                    "content": "[18:07:57] [Render thread\/INFO]: Created: 256x128x0 minecraft:textures\/atlas\/celestials.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:57] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 191,
+                    "content": "[18:07:57] [Render thread\/INFO]: Created: 1024x512x0 minecraft:textures\/atlas\/banner_patterns.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:57] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 192,
+                    "content": "[18:07:57] [Render thread\/INFO]: Created: 512x512x0 minecraft:textures\/atlas\/beds.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:57] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 193,
+                    "content": "[18:07:57] [Render thread\/INFO]: Created: 1024x512x0 minecraft:textures\/atlas\/items.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:57] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 194,
+                    "content": "[18:07:57] [Render thread\/INFO]: Created: 1024x1024x0 minecraft:textures\/atlas\/gui.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:57] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 195,
+                    "content": "[18:07:57] [Render thread\/INFO]: Created: 128x64x0 minecraft:textures\/atlas\/map_decorations.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:57] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 196,
+                    "content": "[18:07:57] [Render thread\/INFO]: Created: 512x256x0 minecraft:textures\/atlas\/signs.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:07:57] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 197,
+                    "content": "[18:07:57] [Render thread\/INFO]: Created: 512x512x0 minecraft:textures\/atlas\/shulker_boxes.png-atlas"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[18:08:00] [Render thread\/INFO]:",
+            "lines": [
+                {
+                    "number": 198,
+                    "content": "[18:08:00] [Render thread\/INFO]: Stopping!"
+                },
+                {
+                    "number": 199,
+                    "content": "Process exited with code 0."
+                },
+                {
+                    "number": 200,
+                    "content": "Log upload triggered at: 30 Mar 2026 18:08:02  0200"
+                },
+                {
+                    "number": 201,
+                    "content": "Log upload canceled"
+                },
+                {
+                    "number": 202,
+                    "content": "Log upload triggered at: 30 Mar 2026 18:08:04  0200"
+                },
+                {
+                    "number": 203,
+                    "content": ""
+                }
+            ]
+        }
+    ],
+    "analysis": {
+        "problems": [],
+        "information": [
+            {
+                "message": "Minecraft version: 26.1",
+                "counter": 1,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[18:07:52] [main\/INFO]:",
+                    "lines": [
+                        {
+                            "number": 131,
+                            "content": "[18:07:52] [main\/INFO]: Loading Minecraft 26.1 with Fabric Loader 0.18.5"
+                        }
+                    ]
+                },
+                "label": "Minecraft version",
+                "value": "26.1"
+            },
+            {
+                "message": "Fabric loader version: 0.18.5",
+                "counter": 1,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[18:07:52] [main\/INFO]:",
+                    "lines": [
+                        {
+                            "number": 131,
+                            "content": "[18:07:52] [main\/INFO]: Loading Minecraft 26.1 with Fabric Loader 0.18.5"
+                        }
+                    ]
+                },
+                "label": "Fabric loader version",
+                "value": "0.18.5"
+            }
+        ]
+    }
+}

--- a/test/data/Vanilla/Fabric/prism-fabric-26-1.log
+++ b/test/data/Vanilla/Fabric/prism-fabric-26-1.log
@@ -1,0 +1,202 @@
+Prism Launcher version: 10.0.5 (official)
+
+
+Launched instance in online mode
+
+login.microsoftonline.com resolves to:
+    [****:****:****:****:****:****:****:****, ****:****:****:****:****:****:****:****, ****:****:****:****:****:****:****:****, ****:****:****:****:****:****:****:****, ****:****:****:****:****:****:****:****, ****:****:****:****:****:****:****:****, ****:****:****:****:****:****:****:****, ****:****:****:****:****:****:****:****, **.**.**.**, **.**.**.**, **.**.**.**, **.**.**.**, **.**.**.**, **.**.**.**, **.**.**.**, **.**.**.**]
+
+
+session.minecraft.net resolves to:
+    [****:****:****:****:****:****:****:****, **.**.**.**]
+
+
+textures.minecraft.net resolves to:
+    [****:****:****:****:****:****:****:****, **.**.**.**]
+
+
+api.mojang.com resolves to:
+    [****:****:****:****:****:****:****:****, **.**.**.**]
+
+
+Minecraft folder is:
+/Users/********/Library/Application Support/PrismLauncher/instances/26.1/minecraft
+
+
+Java path is:
+/Users/********/Library/Application Support/PrismLauncher/java/java-runtime-epsilon/bin/java
+
+
+Java is version 25.0.1, using 64 (aarch64) architecture, from Microsoft.
+
+
+Main Class:
+  net.fabricmc.loader.impl.launch.knot.KnotClient
+
+Native path:
+  /Users/********/Library/Application Support/PrismLauncher/instances/26.1/natives
+
+Traits:
+traits XR:Initial
+traits feature:is_quick_play_multiplayer
+traits feature:is_quick_play_singleplayer
+traits FirstThreadOnMacOS
+
+Libraries:
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/lwjgl/lwjgl-freetype-natives-macos-arm64/3.4.1/lwjgl-freetype-natives-macos-arm64-3.4.1.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/lwjgl/lwjgl-freetype/3.4.1/lwjgl-freetype-3.4.1.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/lwjgl/lwjgl-glfw-natives-macos-arm64/3.4.1/lwjgl-glfw-natives-macos-arm64-3.4.1.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/lwjgl/lwjgl-glfw/3.4.1/lwjgl-glfw-3.4.1.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/lwjgl/lwjgl-jemalloc-natives-macos-arm64/3.4.1/lwjgl-jemalloc-natives-macos-arm64-3.4.1.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/lwjgl/lwjgl-jemalloc/3.4.1/lwjgl-jemalloc-3.4.1.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/lwjgl/lwjgl-natives-macos-arm64/3.4.1/lwjgl-natives-macos-arm64-3.4.1.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/lwjgl/lwjgl-openal-natives-macos-arm64/3.4.1/lwjgl-openal-natives-macos-arm64-3.4.1.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/lwjgl/lwjgl-openal/3.4.1/lwjgl-openal-3.4.1.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/lwjgl/lwjgl-opengl-natives-macos-arm64/3.4.1/lwjgl-opengl-natives-macos-arm64-3.4.1.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/lwjgl/lwjgl-opengl/3.4.1/lwjgl-opengl-3.4.1.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/lwjgl/lwjgl-stb-natives-macos-arm64/3.4.1/lwjgl-stb-natives-macos-arm64-3.4.1.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/lwjgl/lwjgl-stb/3.4.1/lwjgl-stb-3.4.1.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/lwjgl/lwjgl-tinyfd-natives-macos-arm64/3.4.1/lwjgl-tinyfd-natives-macos-arm64-3.4.1.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/lwjgl/lwjgl-tinyfd/3.4.1/lwjgl-tinyfd-3.4.1.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/lwjgl/lwjgl/3.4.1/lwjgl-3.4.1.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/at/yawk/lz4/lz4-java/1.10.1/lz4-java-1.10.1.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/ca/weblite/java-objc-bridge/1.1/java-objc-bridge-1.1.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/com/azure/azure-json/1.4.0/azure-json-1.4.0.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/com/github/oshi/oshi-core/6.9.0/oshi-core-6.9.0.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/com/google/code/gson/gson/2.13.2/gson-2.13.2.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/com/google/guava/failureaccess/1.0.3/failureaccess-1.0.3.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/com/google/guava/guava/33.5.0-jre/guava-33.5.0-jre.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/com/ibm/icu/icu4j/77.1/icu4j-77.1.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/com/microsoft/azure/msal4j/1.23.1/msal4j-1.23.1.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/com/mojang/authlib/7.0.63/authlib-7.0.63.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/com/mojang/blocklist/1.0.10/blocklist-1.0.10.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/com/mojang/brigadier/1.3.10/brigadier-1.3.10.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/com/mojang/datafixerupper/9.0.19/datafixerupper-9.0.19.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/com/mojang/jtracy/1.0.37/jtracy-1.0.37.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/com/mojang/logging/1.6.11/logging-1.6.11.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/com/mojang/patchy/2.2.10/patchy-2.2.10.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/com/mojang/text2speech/1.18.11/text2speech-1.18.11.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/commons-codec/commons-codec/1.19.0/commons-codec-1.19.0.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/commons-io/commons-io/2.20.0/commons-io-2.20.0.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/io/netty/netty-buffer/4.2.7.Final/netty-buffer-4.2.7.Final.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/io/netty/netty-codec-base/4.2.7.Final/netty-codec-base-4.2.7.Final.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/io/netty/netty-codec-compression/4.2.7.Final/netty-codec-compression-4.2.7.Final.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/io/netty/netty-codec-http/4.2.7.Final/netty-codec-http-4.2.7.Final.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/io/netty/netty-common/4.2.7.Final/netty-common-4.2.7.Final.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/io/netty/netty-handler/4.2.7.Final/netty-handler-4.2.7.Final.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/io/netty/netty-resolver/4.2.7.Final/netty-resolver-4.2.7.Final.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/io/netty/netty-transport-classes-epoll/4.2.7.Final/netty-transport-classes-epoll-4.2.7.Final.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/io/netty/netty-transport-classes-kqueue/4.2.7.Final/netty-transport-classes-kqueue-4.2.7.Final.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/io/netty/netty-transport-native-unix-common/4.2.7.Final/netty-transport-native-unix-common-4.2.7.Final.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/io/netty/netty-transport/4.2.7.Final/netty-transport-4.2.7.Final.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/it/unimi/dsi/fastutil/8.5.18/fastutil-8.5.18.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/net/java/dev/jna/jna-platform/5.17.0/jna-platform-5.17.0.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/net/java/dev/jna/jna/5.17.0/jna-5.17.0.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/net/sf/jopt-simple/jopt-simple/5.0.4/jopt-simple-5.0.4.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/apache/commons/commons-compress/1.28.0/commons-compress-1.28.0.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/apache/commons/commons-lang3/3.19.0/commons-lang3-3.19.0.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/apache/logging/log4j/log4j-api/2.25.2/log4j-api-2.25.2.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/apache/logging/log4j/log4j-core/2.25.2/log4j-core-2.25.2.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/apache/logging/log4j/log4j-slf4j2-impl/2.25.2/log4j-slf4j2-impl-2.25.2.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/jcraft/jorbis/0.0.17/jorbis-0.0.17.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/joml/joml/1.10.8/joml-1.10.8.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/slf4j/slf4j-api/2.0.17/slf4j-api-2.0.17.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/net/fabricmc/intermediary/26.1/intermediary-26.1.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/ow2/asm/asm/9.9/asm-9.9.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/ow2/asm/asm-analysis/9.9/asm-analysis-9.9.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/ow2/asm/asm-commons/9.9/asm-commons-9.9.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/ow2/asm/asm-tree/9.9/asm-tree-9.9.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/org/ow2/asm/asm-util/9.9/asm-util-9.9.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/net/fabricmc/sponge-mixin/0.17.0 mixin.0.8.7/sponge-mixin-0.17.0 mixin.0.8.7.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/net/fabricmc/fabric-loader/0.18.5/fabric-loader-0.18.5.jar
+  /Users/********/Library/Application Support/PrismLauncher/libraries/com/mojang/minecraft/26.1/minecraft-26.1-client.jar
+
+Native libraries:
+
+Params:
+  --username  --version 26.1 --gameDir /Users/********/Library/Application Support/PrismLauncher/instances/26.1/minecraft --assetsDir /Users/********/Library/Application Support/PrismLauncher/assets --assetIndex 30 --uuid  --accessToken  --versionType release
+
+Window size: 854 x 480
+
+Launcher: standard
+
+Java Arguments:
+[-Xdock:icon=icon.png, -Xdock:name="Prism Launcher: 26.1", -XstartOnFirstThread, -Xms512m, -Xmx8192m, -Duser.language=en]
+
+
+Minecraft process ID: 43959
+
+
+[18:07:52] [main/INFO]: Loading Minecraft 26.1 with Fabric Loader 0.18.5
+[18:07:52] [main/INFO]: Loading 4 mods:
+	- fabricloader 0.18.5
+	   \-- mixinextras 0.5.3
+	- java 25
+	- minecraft 26.1
+[18:07:52] [main/INFO]: SpongePowered MIXIN Subsystem Version=0.8.7 Source=file:/Users/********/Library/Application Support/PrismLauncher/libraries/net/fabricmc/sponge-mixin/0.17.0 mixin.0.8.7/sponge-mixin-0.17.0 mixin.0.8.7.jar Service=Knot/Fabric Env=CLIENT
+WARNING: A restricted method in java.lang.System has been called
+WARNING: java.lang.System::load has been called by com.sun.jna.Native in an unnamed module (file:/Users/********/Library/Application Support/PrismLauncher/libraries/net/java/dev/jna/jna/5.17.0/jna-5.17.0.jar)
+WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
+WARNING: Restricted methods will be blocked in a future release unless native access is enabled
+[18:07:52] [Datafixer Bootstrap/INFO]: 291 Datafixer optimizations took 103 milliseconds
+WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
+WARNING: sun.misc.Unsafe::objectFieldOffset has been called by org.joml.MemUtil$MemUtilUnsafe (file:/Users/********/Library/Application Support/PrismLauncher/libraries/org/joml/joml/1.10.8/joml-1.10.8.jar)
+WARNING: Please consider reporting this to the maintainers of class org.joml.MemUtil$MemUtilUnsafe
+WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
+[18:07:54] [Render thread/INFO]: Environment: Environment[sessionHost=https://sessionserver.mojang.com, servicesHost=https://api.minecraftservices.com, profilesHost=https://api.mojang.com, name=PROD]
+[18:07:54] [Render thread/INFO]: Setting user: NutellaGolem
+[18:07:54] [Render thread/INFO]: Backend library: LWJGL version 3.4.1-snapshot
+[18:07:55] [Render thread/INFO]: Using optional rendering extensions: GL_EXT_texture_filter_anisotropic
+[18:07:56] [Render thread/INFO]: Reloading ResourceManager: vanilla
+[18:07:56] [Worker-Main-3/INFO]: Found unifont_all_no_pua-17.0.01.hex, loading
+[18:07:56] [Worker-Main-6/INFO]: Found unifont_pua-17.0.01.hex, loading
+[18:07:56] [Worker-Main-7/INFO]: Found unifont_jp_patch-17.0.01.hex, loading
+[18:07:56] [Render thread/INFO]: Info log when linking program containing VS minecraft:core/entity and FS minecraft:core/entity. Log output: WARNING: Could not find vertex shader attribute 'UV1' to match BindAttributeLocation request.
+[18:07:56] [Render thread/INFO]: Info log when linking program containing VS minecraft:core/entity and FS minecraft:core/entity. Log output: WARNING: Could not find vertex shader attribute 'UV1' to match BindAttributeLocation request.
+[18:07:56] [Render thread/INFO]: Info log when linking program containing VS minecraft:core/rendertype_text_background_see_through and FS minecraft:core/rendertype_text_background_see_through. Log output: WARNING: Could not find vertex shader attribute 'UV2' to match BindAttributeLocation request.
+[18:07:56] [Render thread/INFO]: Info log when linking program containing VS minecraft:core/entity and FS minecraft:core/entity. Log output: WARNING: Could not find vertex shader attribute 'UV1' to match BindAttributeLocation request.
+[18:07:56] [Render thread/INFO]: Info log when linking program containing VS minecraft:core/item and FS minecraft:core/item. Log output: WARNING: Could not find vertex shader attribute 'UV1' to match BindAttributeLocation request.
+[18:07:56] [Render thread/INFO]: Info log when linking program containing VS minecraft:core/rendertype_beacon_beam and FS minecraft:core/rendertype_beacon_beam. Log output: WARNING: Could not find vertex shader attribute 'UV2' to match BindAttributeLocation request.
+[18:07:56] [Render thread/INFO]: Info log when linking program containing VS minecraft:core/rendertype_beacon_beam and FS minecraft:core/rendertype_beacon_beam. Log output: WARNING: Could not find vertex shader attribute 'UV2' to match BindAttributeLocation request.
+[18:07:56] [Render thread/INFO]: Info log when linking program containing VS minecraft:core/entity and FS minecraft:core/entity. Log output: WARNING: Could not find vertex shader attribute 'UV2' to match BindAttributeLocation request.
+[18:07:56] [Render thread/INFO]: Info log when linking program containing VS minecraft:core/rendertype_text_intensity_see_through and FS minecraft:core/rendertype_text_intensity_see_through. Log output: WARNING: Could not find vertex shader attribute 'UV2' to match BindAttributeLocation request.
+[18:07:56] [Render thread/INFO]: Info log when linking program containing VS minecraft:core/entity and FS minecraft:core/entity. Log output: WARNING: Could not find vertex shader attribute 'UV1' to match BindAttributeLocation request.
+[18:07:56] [Render thread/INFO]: Info log when linking program containing VS minecraft:core/entity and FS minecraft:core/entity. Log output: WARNING: Could not find vertex shader attribute 'UV1' to match BindAttributeLocation request.
+[18:07:56] [Render thread/INFO]: Info log when linking program containing VS minecraft:core/entity and FS minecraft:core/entity. Log output: WARNING: Could not find vertex shader attribute 'UV1' to match BindAttributeLocation request.
+WARNING: Could not find vertex shader attribute 'Normal' to match BindAttributeLocation request.
+WARNING: Could not find vertex shader attribute 'UV2' to match BindAttributeLocation request.
+[18:07:56] [Render thread/INFO]: Info log when linking program containing VS minecraft:core/animate_sprite and FS minecraft:core/animate_sprite_blit. Log output: WARNING: Output of vertex shader 'fAnimationProgress' not read by fragment shader
+[18:07:56] [Render thread/INFO]: Info log when linking program containing VS minecraft:core/rendertype_entity_shadow and FS minecraft:core/rendertype_entity_shadow. Log output: WARNING: Could not find vertex shader attribute 'UV1' to match BindAttributeLocation request.
+WARNING: Could not find vertex shader attribute 'Normal' to match BindAttributeLocation request.
+WARNING: Could not find vertex shader attribute 'UV2' to match BindAttributeLocation request.
+[18:07:56] [Render thread/INFO]: Info log when linking program containing VS minecraft:core/entity and FS minecraft:core/entity. Log output: WARNING: Could not find vertex shader attribute 'UV1' to match BindAttributeLocation request.
+WARNING: Could not find vertex shader attribute 'Normal' to match BindAttributeLocation request.
+[18:07:56] [Render thread/INFO]: Info log when linking program containing VS minecraft:core/rendertype_text_see_through and FS minecraft:core/rendertype_text_see_through. Log output: WARNING: Could not find vertex shader attribute 'UV2' to match BindAttributeLocation request.
+[18:07:56] [Render thread/INFO]: Info log when linking program containing VS minecraft:core/entity and FS minecraft:core/entity. Log output: WARNING: Could not find vertex shader attribute 'UV1' to match BindAttributeLocation request.
+WARNING: Could not find vertex shader attribute 'Normal' to match BindAttributeLocation request.
+WARNING: Could not find vertex shader attribute 'UV2' to match BindAttributeLocation request.
+[18:07:56] [Render thread/INFO]: Info log when linking program containing VS minecraft:core/item and FS minecraft:core/item. Log output: WARNING: Could not find vertex shader attribute 'UV1' to match BindAttributeLocation request.
+[18:07:56] [Render thread/INFO]: Info log when linking program containing VS minecraft:core/rendertype_crumbling and FS minecraft:core/rendertype_crumbling. Log output: WARNING: Could not find vertex shader attribute 'UV2' to match BindAttributeLocation request.
+[18:07:56] [Render thread/INFO]: OpenAL initialized on device MacBook Pro Speakers
+[18:07:56] [Render thread/INFO]: Sound engine started
+[18:07:56] [Render thread/INFO]: Created: 512x256x0 minecraft:textures/atlas/particles.png-atlas
+[18:07:56] [Render thread/INFO]: Created: 128x128x0 minecraft:textures/atlas/decorated_pot.png-atlas
+[18:07:56] [Render thread/INFO]: Created: 2048x1024x0 minecraft:textures/atlas/armor_trims.png-atlas
+[18:07:56] [Render thread/INFO]: Created: 512x256x0 minecraft:textures/atlas/paintings.png-atlas
+[18:07:56] [Render thread/INFO]: Created: 1024x512x0 minecraft:textures/atlas/shield_patterns.png-atlas
+[18:07:56] [Render thread/INFO]: Created: 2048x2048x4 minecraft:textures/atlas/blocks.png-atlas
+[18:07:57] [Render thread/INFO]: Created: 512x512x0 minecraft:textures/atlas/chest.png-atlas
+[18:07:57] [Render thread/INFO]: Created: 256x128x0 minecraft:textures/atlas/celestials.png-atlas
+[18:07:57] [Render thread/INFO]: Created: 1024x512x0 minecraft:textures/atlas/banner_patterns.png-atlas
+[18:07:57] [Render thread/INFO]: Created: 512x512x0 minecraft:textures/atlas/beds.png-atlas
+[18:07:57] [Render thread/INFO]: Created: 1024x512x0 minecraft:textures/atlas/items.png-atlas
+[18:07:57] [Render thread/INFO]: Created: 1024x1024x0 minecraft:textures/atlas/gui.png-atlas
+[18:07:57] [Render thread/INFO]: Created: 128x64x0 minecraft:textures/atlas/map_decorations.png-atlas
+[18:07:57] [Render thread/INFO]: Created: 512x256x0 minecraft:textures/atlas/signs.png-atlas
+[18:07:57] [Render thread/INFO]: Created: 512x512x0 minecraft:textures/atlas/shulker_boxes.png-atlas
+[18:08:00] [Render thread/INFO]: Stopping!
+Process exited with code 0.
+Log upload triggered at: 30 Mar 2026 18:08:02  0200
+Log upload canceled
+Log upload triggered at: 30 Mar 2026 18:08:04  0200

--- a/test/tests/Logs/AutoLogsTest.php
+++ b/test/tests/Logs/AutoLogsTest.php
@@ -1118,6 +1118,16 @@ class AutoLogsTest extends \PHPUnit\Framework\TestCase
      * @return void
      * @throws Exception
      */
+    public function test_prism_fabric_26_1(): void
+    {
+        $log = new TestLog('Vanilla/Fabric/prism-fabric-26-1.log');
+        $this->assertStringEqualsFile($log->getExpectedPath(), $log->getOutput(), $log->getLogPath());
+    }
+
+    /**
+     * @return void
+     * @throws Exception
+     */
     public function test_arclight_1192(): void
     {
         $log = new TestLog('Vanilla/Forge/Arclight/arclight-1192.log');


### PR DESCRIPTION
The multiline flag was missing from one of the patterns for fabric client logs, requiring that line to be the first of the log.