### PR TITLE
Add FabricModIncompatibleMinecraftVersionProblem

### DIFF
--- a/src/Analyser/FabricAnalyser.php
+++ b/src/Analyser/FabricAnalyser.php
@@ -11,6 +11,7 @@ use Aternos\Codex\Minecraft\Analysis\Problem\Fabric\FabricEntryStageProblem;
 use Aternos\Codex\Minecraft\Analysis\Problem\Fabric\FabricIncompatibleModsProblem;
 use Aternos\Codex\Minecraft\Analysis\Problem\Fabric\FabricMixinProblem;
 use Aternos\Codex\Minecraft\Analysis\Problem\Fabric\FabricModDependencyProblem;
+use Aternos\Codex\Minecraft\Analysis\Problem\Fabric\FabricModIncompatibleMinecraftVersionProblem;
 
 class FabricAnalyser extends VanillaAnalyser
 {
@@ -21,6 +22,7 @@ class FabricAnalyser extends VanillaAnalyser
         $this->overridePossibleInsightClass(VanillaVersionInformation::class, FabricVanillaVersionInformation::class);
         $this->addPossibleInsightClass(FabricJavaVersionInformation::class);
         $this->addPossibleInsightClass(FabricModDependencyProblem::class);
+        $this->addPossibleInsightClass(FabricModIncompatibleMinecraftVersionProblem::class);
         $this->addPossibleInsightClass(FabricMixinProblem::class);
         $this->addPossibleInsightClass(FabricIncompatibleModsProblem::class);
         $this->addPossibleInsightClass(FabricDuplicateModProblem::class);

--- a/src/Analysis/Problem/Fabric/FabricModIncompatibleMinecraftVersionProblem.php
+++ b/src/Analysis/Problem/Fabric/FabricModIncompatibleMinecraftVersionProblem.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Aternos\Codex\Minecraft\Analysis\Problem\Fabric;
+
+use Aternos\Codex\Analysis\InsightInterface;
+use Aternos\Codex\Minecraft\Analysis\Information\Fabric\FabricVanillaVersionInformation;
+use Aternos\Codex\Minecraft\Analysis\Solution\Bukkit\ServerInstallDifferentVersionSolution;
+use Aternos\Codex\Minecraft\Analysis\Solution\Forge\ModInstallDifferentVersionSolution;
+use Aternos\Codex\Minecraft\Translator\Translator;
+
+class FabricModIncompatibleMinecraftVersionProblem extends FabricModProblem
+{
+    protected string $minecraftVersion;
+
+    /**
+     * @return string
+     */
+    public function getMinecraftVersion(): string
+    {
+        return $this->minecraftVersion;
+    }
+
+    /**
+     * @param string $minecraftVersion
+     * @return $this
+     */
+    protected function setMinecraftVersion(string $minecraftVersion): static
+    {
+        $this->minecraftVersion = $minecraftVersion;
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getMessage(): string
+    {
+        return Translator::getInstance()->getTranslation("mod-wrong-minecraft-version-problem", [
+            "mod-name" => $this->getModName(),
+            "minecraft-version" => $this->getMinecraftVersion()
+        ]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getPatterns(): array
+    {
+        return [
+            'any' => "/\s*- Mod " . static::$modNamePattern . "(?: [^ ]+)? requires any version of (?:mod )?'Minecraft' \(minecraft\), but only the wrong version is present: (" . FabricVanillaVersionInformation::getVersionPattern() . ")!/",
+            'minimum' => "/\s*- Mod " . static::$modNamePattern . "(?: [^ ]+)? requires version ([^ ]+) or later of (?:mod )'Minecraft' \(minecraft\), but only the wrong version is present: (" . FabricVanillaVersionInformation::getVersionPattern() . ")!/",
+            'any-after' => "/\s*- Mod " . static::$modNamePattern . "(?: [^ ]+)? requires any version after ([^ ]+) of (?:mod )?'Minecraft' \(minecraft\), but only the wrong version is present: (" . FabricVanillaVersionInformation::getVersionPattern() . ")!/",
+            'any-before' => "/\s*- Mod " . static::$modNamePattern . "(?: [^ ]+)? requires any version before ([^ ]+) of (?:mod )?'Minecraft' \(minecraft\), but only the wrong version is present: (" . FabricVanillaVersionInformation::getVersionPattern() . ")!/",
+            'specific' => "/\s*- Mod " . static::$modNamePattern . "(?: [^ ]+)? requires version ([^ ]+) of (?:mod )?'Minecraft' \(minecraft\), but only the wrong version is present: (" . FabricVanillaVersionInformation::getVersionPattern() . ")!/",
+            'between' => "/\s*- Mod " . static::$modNamePattern . "(?: [^ ]+)? requires any version between ([^ ]+) \((inclusive|exclusive)\) and ([^ ]+) \((inclusive|exclusive)\) of (?:mod )?'Minecraft' \(minecraft\), but only the wrong version is present: (" . FabricVanillaVersionInformation::getVersionPattern() . ")!/",
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setMatches(array $matches, mixed $patternKey): void
+    {
+        switch ($patternKey) {
+            case 'any':
+                $wrongVersion = $matches[2];
+                $this->setMinecraftVersion($wrongVersion);
+
+                $this->setModName($matches[1]);
+                $this->addSolution(new ModInstallDifferentVersionSolution($this->getModName()));
+                return;
+
+            case 'minimum':
+                $symbol = ">=";
+                break;
+
+            case 'any-after':
+                $symbol = ">";
+                break;
+
+            case 'any-before':
+                $symbol = "<";
+                break;
+
+            case 'between':
+                $wrongVersion = $matches[7];
+                $this->setMinecraftVersion($wrongVersion);
+
+                $this->setModName($matches[1]);
+
+                $firstSymbol = $matches[4] === "exclusive" ? ">" : ">=";
+                $secondSymbol = $matches[6] === "exclusive" ? "<" : "<=";
+                $version = $firstSymbol . $matches[3] . ", " . $secondSymbol . $matches[5];
+
+                $this->addSolution(new ServerInstallDifferentVersionSolution($version));
+                $this->addSolution(new ModInstallDifferentVersionSolution($this->getModName()));
+                return;
+
+            default:
+                $symbol = "";
+                break;
+        }
+
+        $wrongVersion = $matches[4];
+        $this->setMinecraftVersion($wrongVersion);
+
+        $this->setModName($matches[1]);
+        $version = $symbol . $matches[3];
+
+        $this->addSolution(new ServerInstallDifferentVersionSolution($version));
+        $this->addSolution(new ModInstallDifferentVersionSolution($this->getModName()));
+    }
+
+    /**
+     * @param InsightInterface $insight
+     * @return bool
+     */
+    public function isEqual(InsightInterface $insight): bool
+    {
+        return $insight instanceof static
+            && parent::isEqual($insight)
+            && $this->getMinecraftVersion() === $insight->getMinecraftVersion();
+    }
+}

--- a/src/Analysis/Problem/Fabric/FabricModProblem.php
+++ b/src/Analysis/Problem/Fabric/FabricModProblem.php
@@ -11,7 +11,7 @@ abstract class FabricModProblem extends FabricProblem
      */
     protected const array MOD_NAME_REPLACEMENTS = ["fabric" => "FabricAPI"];
 
-    protected static string $modNamePattern = "(?:'([^\']+)' \((?:[^\)]+)\)|([\w-]+))";
+    protected static string $modNamePattern = "(?:'(?!Minecraft')([^']+)' \((?:[^\)]+)\)|([\w-]+))";
     protected static string $modIDPattern = "([^ ,]+)";
 
     protected string $modName;

--- a/test/data/Vanilla/Fabric/fabric-incompatible-minecraft-version.json
+++ b/test/data/Vanilla/Fabric/fabric-incompatible-minecraft-version.json
@@ -1,0 +1,352 @@
+{
+    "id": "fabric\/server",
+    "name": "Fabric",
+    "type": "Server Log",
+    "version": "1.16.5",
+    "title": "Fabric 1.16.5 Server Log",
+    "entries": [
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[11:09:00] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 1,
+                    "content": "[11:09:00] [main\/INFO]: Loading Minecraft 1.16.5 with Fabric Loader 0.19.2"
+                }
+            ]
+        },
+        {
+            "level": 4,
+            "time": null,
+            "prefix": "[11:09:00] [main\/WARN]:",
+            "lines": [
+                {
+                    "number": 2,
+                    "content": "[11:09:00] [main\/WARN]: Mod resolution failed"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[11:09:00] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 3,
+                    "content": "[11:09:00] [main\/INFO]: Immediate reason: [ROOT_FORCELOAD_SINGLE fabric-api 0.141.3+1.21.11]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[11:09:00] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 4,
+                    "content": "[11:09:00] [main\/INFO]: Reason: [HARD_DEP fabric-api 0.141.3+1.21.11 {depends minecraft @ [>=1.21.11- <1.21.12-]}, HARD_DEP fabric-command-api-v2 2.4.7+6b42a6003e {depends minecraft @ [>1.19-alpha.22.11.a]}, HARD_DEP fabric-convention-tags-v1 2.1.55+7f945d5b3e {depends minecraft @ [>=1.18.2]}, HARD_DEP fabric-convention-tags-v2 2.17.3+8ef948ba3e {depends minecraft @ [>=1.20.5-beta.1]}]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[11:09:00] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 5,
+                    "content": "[11:09:00] [main\/INFO]: SERVER environment disabled: [fabric-model-loading-api-v1, fabric-renderer-api-v1, fabric-screen-api-v1, fabric-sound-api-v1, fabric-rendering-v1, fabric-key-binding-api-v1, fabric-renderer-indigo]"
+                }
+            ]
+        },
+        {
+            "level": 6,
+            "time": null,
+            "prefix": "[11:09:00] [main\/INFO]:",
+            "lines": [
+                {
+                    "number": 6,
+                    "content": "[11:09:00] [main\/INFO]: Fix: add [], remove [], replace [[minecraft 1.16.5] -> add:minecraft 1.21.11- ([[1.21.11-,1.21.12-)])]"
+                }
+            ]
+        },
+        {
+            "level": 3,
+            "time": null,
+            "prefix": "[11:09:00] [main\/ERROR]:",
+            "lines": [
+                {
+                    "number": 7,
+                    "content": "[11:09:00] [main\/ERROR]: Incompatible mods found!"
+                },
+                {
+                    "number": 8,
+                    "content": "net.fabricmc.loader.impl.FormattedException: Some of your mods are incompatible with the game or each other!"
+                },
+                {
+                    "number": 9,
+                    "content": "A potential solution has been determined, this may resolve your problem:"
+                },
+                {
+                    "number": 10,
+                    "content": "\t - Replace 'Minecraft' (minecraft) 1.16.5 with any version between 1.21.11- (inclusive) and 1.21.12- (exclusive)."
+                },
+                {
+                    "number": 11,
+                    "content": "More details:"
+                },
+                {
+                    "number": 12,
+                    "content": "\t - Mod 'Fabric API' (fabric-api) 0.141.3+1.21.11 requires any version between 1.21.11- (inclusive) and 1.21.12- (exclusive) of 'Minecraft' (minecraft), but only the wrong version is present: 1.16.5!"
+                },
+                {
+                    "number": 13,
+                    "content": "\t - Mod 'Fabric Command API (v2)' (fabric-command-api-v2) 2.4.7+6b42a6003e requires any version after 1.19-alpha.22.11.a of 'Minecraft' (minecraft), but only the wrong version is present: 1.16.5!"
+                },
+                {
+                    "number": 14,
+                    "content": "\t - Mod 'Fabric Convention Tags' (fabric-convention-tags-v1) 2.1.55+7f945d5b3e requires version 1.18.2 or later of 'Minecraft' (minecraft), but only the wrong version is present: 1.16.5!"
+                },
+                {
+                    "number": 15,
+                    "content": "\t - Mod 'Fabric Convention Tags (v2)' (fabric-convention-tags-v2) 2.17.3+8ef948ba3e requires version 1.20.5-beta.1 or later of 'Minecraft' (minecraft), but only the wrong version is present: 1.16.5!"
+                },
+                {
+                    "number": 16,
+                    "content": "\tat net.fabricmc.loader.impl.FormattedException.ofLocalized(FormattedException.java:51) ~[fabric-loader-0.19.2.jar:?]"
+                },
+                {
+                    "number": 17,
+                    "content": "\tat net.fabricmc.loader.impl.FabricLoaderImpl.load(FabricLoaderImpl.java:202) ~[fabric-loader-0.19.2.jar:?]"
+                },
+                {
+                    "number": 18,
+                    "content": "\tat net.fabricmc.loader.impl.launch.knot.Knot.init(Knot.java:142) ~[fabric-loader-0.19.2.jar:?]"
+                },
+                {
+                    "number": 19,
+                    "content": "\tat net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:66) [fabric-loader-0.19.2.jar:?]"
+                },
+                {
+                    "number": 20,
+                    "content": "\tat net.fabricmc.loader.impl.launch.knot.KnotServer.main(KnotServer.java:23) [fabric-loader-0.19.2.jar:?]"
+                },
+                {
+                    "number": 21,
+                    "content": "\tat net.fabricmc.loader.impl.launch.server.FabricServerLauncher.main(FabricServerLauncher.java:69) [fabric-loader-0.19.2.jar:?]"
+                },
+                {
+                    "number": 22,
+                    "content": ""
+                }
+            ]
+        }
+    ],
+    "analysis": {
+        "problems": [
+            {
+                "message": "The mod 'Fabric Command API (v2)' is not compatible with the Minecraft version 1.16.5.",
+                "counter": 1,
+                "entry": {
+                    "level": 3,
+                    "time": null,
+                    "prefix": "[11:09:00] [main\/ERROR]:",
+                    "lines": [
+                        {
+                            "number": 7,
+                            "content": "[11:09:00] [main\/ERROR]: Incompatible mods found!"
+                        },
+                        {
+                            "number": 8,
+                            "content": "net.fabricmc.loader.impl.FormattedException: Some of your mods are incompatible with the game or each other!"
+                        },
+                        {
+                            "number": 9,
+                            "content": "A potential solution has been determined, this may resolve your problem:"
+                        },
+                        {
+                            "number": 10,
+                            "content": "\t - Replace 'Minecraft' (minecraft) 1.16.5 with any version between 1.21.11- (inclusive) and 1.21.12- (exclusive)."
+                        },
+                        {
+                            "number": 11,
+                            "content": "More details:"
+                        },
+                        {
+                            "number": 12,
+                            "content": "\t - Mod 'Fabric API' (fabric-api) 0.141.3+1.21.11 requires any version between 1.21.11- (inclusive) and 1.21.12- (exclusive) of 'Minecraft' (minecraft), but only the wrong version is present: 1.16.5!"
+                        },
+                        {
+                            "number": 13,
+                            "content": "\t - Mod 'Fabric Command API (v2)' (fabric-command-api-v2) 2.4.7+6b42a6003e requires any version after 1.19-alpha.22.11.a of 'Minecraft' (minecraft), but only the wrong version is present: 1.16.5!"
+                        },
+                        {
+                            "number": 14,
+                            "content": "\t - Mod 'Fabric Convention Tags' (fabric-convention-tags-v1) 2.1.55+7f945d5b3e requires version 1.18.2 or later of 'Minecraft' (minecraft), but only the wrong version is present: 1.16.5!"
+                        },
+                        {
+                            "number": 15,
+                            "content": "\t - Mod 'Fabric Convention Tags (v2)' (fabric-convention-tags-v2) 2.17.3+8ef948ba3e requires version 1.20.5-beta.1 or later of 'Minecraft' (minecraft), but only the wrong version is present: 1.16.5!"
+                        },
+                        {
+                            "number": 16,
+                            "content": "\tat net.fabricmc.loader.impl.FormattedException.ofLocalized(FormattedException.java:51) ~[fabric-loader-0.19.2.jar:?]"
+                        },
+                        {
+                            "number": 17,
+                            "content": "\tat net.fabricmc.loader.impl.FabricLoaderImpl.load(FabricLoaderImpl.java:202) ~[fabric-loader-0.19.2.jar:?]"
+                        },
+                        {
+                            "number": 18,
+                            "content": "\tat net.fabricmc.loader.impl.launch.knot.Knot.init(Knot.java:142) ~[fabric-loader-0.19.2.jar:?]"
+                        },
+                        {
+                            "number": 19,
+                            "content": "\tat net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:66) [fabric-loader-0.19.2.jar:?]"
+                        },
+                        {
+                            "number": 20,
+                            "content": "\tat net.fabricmc.loader.impl.launch.knot.KnotServer.main(KnotServer.java:23) [fabric-loader-0.19.2.jar:?]"
+                        },
+                        {
+                            "number": 21,
+                            "content": "\tat net.fabricmc.loader.impl.launch.server.FabricServerLauncher.main(FabricServerLauncher.java:69) [fabric-loader-0.19.2.jar:?]"
+                        },
+                        {
+                            "number": 22,
+                            "content": ""
+                        }
+                    ]
+                },
+                "solutions": [
+                    {
+                        "message": "Install the version '>1.19-alpha.22.11.a' of your server software."
+                    },
+                    {
+                        "message": "Install a different version of the mod 'Fabric Command API (v2)'."
+                    }
+                ]
+            },
+            {
+                "message": "The mod 'Fabric API' is not compatible with the Minecraft version 1.16.5.",
+                "counter": 1,
+                "entry": {
+                    "level": 3,
+                    "time": null,
+                    "prefix": "[11:09:00] [main\/ERROR]:",
+                    "lines": [
+                        {
+                            "number": 7,
+                            "content": "[11:09:00] [main\/ERROR]: Incompatible mods found!"
+                        },
+                        {
+                            "number": 8,
+                            "content": "net.fabricmc.loader.impl.FormattedException: Some of your mods are incompatible with the game or each other!"
+                        },
+                        {
+                            "number": 9,
+                            "content": "A potential solution has been determined, this may resolve your problem:"
+                        },
+                        {
+                            "number": 10,
+                            "content": "\t - Replace 'Minecraft' (minecraft) 1.16.5 with any version between 1.21.11- (inclusive) and 1.21.12- (exclusive)."
+                        },
+                        {
+                            "number": 11,
+                            "content": "More details:"
+                        },
+                        {
+                            "number": 12,
+                            "content": "\t - Mod 'Fabric API' (fabric-api) 0.141.3+1.21.11 requires any version between 1.21.11- (inclusive) and 1.21.12- (exclusive) of 'Minecraft' (minecraft), but only the wrong version is present: 1.16.5!"
+                        },
+                        {
+                            "number": 13,
+                            "content": "\t - Mod 'Fabric Command API (v2)' (fabric-command-api-v2) 2.4.7+6b42a6003e requires any version after 1.19-alpha.22.11.a of 'Minecraft' (minecraft), but only the wrong version is present: 1.16.5!"
+                        },
+                        {
+                            "number": 14,
+                            "content": "\t - Mod 'Fabric Convention Tags' (fabric-convention-tags-v1) 2.1.55+7f945d5b3e requires version 1.18.2 or later of 'Minecraft' (minecraft), but only the wrong version is present: 1.16.5!"
+                        },
+                        {
+                            "number": 15,
+                            "content": "\t - Mod 'Fabric Convention Tags (v2)' (fabric-convention-tags-v2) 2.17.3+8ef948ba3e requires version 1.20.5-beta.1 or later of 'Minecraft' (minecraft), but only the wrong version is present: 1.16.5!"
+                        },
+                        {
+                            "number": 16,
+                            "content": "\tat net.fabricmc.loader.impl.FormattedException.ofLocalized(FormattedException.java:51) ~[fabric-loader-0.19.2.jar:?]"
+                        },
+                        {
+                            "number": 17,
+                            "content": "\tat net.fabricmc.loader.impl.FabricLoaderImpl.load(FabricLoaderImpl.java:202) ~[fabric-loader-0.19.2.jar:?]"
+                        },
+                        {
+                            "number": 18,
+                            "content": "\tat net.fabricmc.loader.impl.launch.knot.Knot.init(Knot.java:142) ~[fabric-loader-0.19.2.jar:?]"
+                        },
+                        {
+                            "number": 19,
+                            "content": "\tat net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:66) [fabric-loader-0.19.2.jar:?]"
+                        },
+                        {
+                            "number": 20,
+                            "content": "\tat net.fabricmc.loader.impl.launch.knot.KnotServer.main(KnotServer.java:23) [fabric-loader-0.19.2.jar:?]"
+                        },
+                        {
+                            "number": 21,
+                            "content": "\tat net.fabricmc.loader.impl.launch.server.FabricServerLauncher.main(FabricServerLauncher.java:69) [fabric-loader-0.19.2.jar:?]"
+                        },
+                        {
+                            "number": 22,
+                            "content": ""
+                        }
+                    ]
+                },
+                "solutions": [
+                    {
+                        "message": "Install the version '>=1.21.11-, <1.21.12-' of your server software."
+                    },
+                    {
+                        "message": "Install a different version of the mod 'Fabric API'."
+                    }
+                ]
+            }
+        ],
+        "information": [
+            {
+                "message": "Minecraft version: 1.16.5",
+                "counter": 1,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[11:09:00] [main\/INFO]:",
+                    "lines": [
+                        {
+                            "number": 1,
+                            "content": "[11:09:00] [main\/INFO]: Loading Minecraft 1.16.5 with Fabric Loader 0.19.2"
+                        }
+                    ]
+                },
+                "label": "Minecraft version",
+                "value": "1.16.5"
+            },
+            {
+                "message": "Fabric loader version: 0.19.2",
+                "counter": 1,
+                "entry": {
+                    "level": 6,
+                    "time": null,
+                    "prefix": "[11:09:00] [main\/INFO]:",
+                    "lines": [
+                        {
+                            "number": 1,
+                            "content": "[11:09:00] [main\/INFO]: Loading Minecraft 1.16.5 with Fabric Loader 0.19.2"
+                        }
+                    ]
+                },
+                "label": "Fabric loader version",
+                "value": "0.19.2"
+            }
+        ]
+    }
+}

--- a/test/data/Vanilla/Fabric/fabric-incompatible-minecraft-version.log
+++ b/test/data/Vanilla/Fabric/fabric-incompatible-minecraft-version.log
@@ -1,0 +1,21 @@
+[11:09:00] [main/INFO]: Loading Minecraft 1.16.5 with Fabric Loader 0.19.2
+[11:09:00] [main/WARN]: Mod resolution failed
+[11:09:00] [main/INFO]: Immediate reason: [ROOT_FORCELOAD_SINGLE fabric-api 0.141.3+1.21.11]
+[11:09:00] [main/INFO]: Reason: [HARD_DEP fabric-api 0.141.3+1.21.11 {depends minecraft @ [>=1.21.11- <1.21.12-]}, HARD_DEP fabric-command-api-v2 2.4.7+6b42a6003e {depends minecraft @ [>1.19-alpha.22.11.a]}, HARD_DEP fabric-convention-tags-v1 2.1.55+7f945d5b3e {depends minecraft @ [>=1.18.2]}, HARD_DEP fabric-convention-tags-v2 2.17.3+8ef948ba3e {depends minecraft @ [>=1.20.5-beta.1]}]
+[11:09:00] [main/INFO]: SERVER environment disabled: [fabric-model-loading-api-v1, fabric-renderer-api-v1, fabric-screen-api-v1, fabric-sound-api-v1, fabric-rendering-v1, fabric-key-binding-api-v1, fabric-renderer-indigo]
+[11:09:00] [main/INFO]: Fix: add [], remove [], replace [[minecraft 1.16.5] -> add:minecraft 1.21.11- ([[1.21.11-,1.21.12-)])]
+[11:09:00] [main/ERROR]: Incompatible mods found!
+net.fabricmc.loader.impl.FormattedException: Some of your mods are incompatible with the game or each other!
+A potential solution has been determined, this may resolve your problem:
+	 - Replace 'Minecraft' (minecraft) 1.16.5 with any version between 1.21.11- (inclusive) and 1.21.12- (exclusive).
+More details:
+	 - Mod 'Fabric API' (fabric-api) 0.141.3+1.21.11 requires any version between 1.21.11- (inclusive) and 1.21.12- (exclusive) of 'Minecraft' (minecraft), but only the wrong version is present: 1.16.5!
+	 - Mod 'Fabric Command API (v2)' (fabric-command-api-v2) 2.4.7+6b42a6003e requires any version after 1.19-alpha.22.11.a of 'Minecraft' (minecraft), but only the wrong version is present: 1.16.5!
+	 - Mod 'Fabric Convention Tags' (fabric-convention-tags-v1) 2.1.55+7f945d5b3e requires version 1.18.2 or later of 'Minecraft' (minecraft), but only the wrong version is present: 1.16.5!
+	 - Mod 'Fabric Convention Tags (v2)' (fabric-convention-tags-v2) 2.17.3+8ef948ba3e requires version 1.20.5-beta.1 or later of 'Minecraft' (minecraft), but only the wrong version is present: 1.16.5!
+	at net.fabricmc.loader.impl.FormattedException.ofLocalized(FormattedException.java:51) ~[fabric-loader-0.19.2.jar:?]
+	at net.fabricmc.loader.impl.FabricLoaderImpl.load(FabricLoaderImpl.java:202) ~[fabric-loader-0.19.2.jar:?]
+	at net.fabricmc.loader.impl.launch.knot.Knot.init(Knot.java:142) ~[fabric-loader-0.19.2.jar:?]
+	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:66) [fabric-loader-0.19.2.jar:?]
+	at net.fabricmc.loader.impl.launch.knot.KnotServer.main(KnotServer.java:23) [fabric-loader-0.19.2.jar:?]
+	at net.fabricmc.loader.impl.launch.server.FabricServerLauncher.main(FabricServerLauncher.java:69) [fabric-loader-0.19.2.jar:?]

--- a/test/data/Vanilla/Fabric/fabric-version-range-dependency.json
+++ b/test/data/Vanilla/Fabric/fabric-version-range-dependency.json
@@ -134,7 +134,7 @@
     "analysis": {
         "problems": [
             {
-                "message": "The mod 'Fabric API' is missing the required mod 'Minecraft'.",
+                "message": "The mod 'Fabric API' is not compatible with the Minecraft version 1.18.2.",
                 "counter": 1,
                 "entry": {
                     "level": 3,
@@ -197,12 +197,15 @@
                 },
                 "solutions": [
                     {
-                        "message": "Install the mod 'Minecraft' with version >=1.19-alpha.22.18.a, <1.20-."
+                        "message": "Install the version '>=1.19-alpha.22.18.a, <1.20-' of your server software."
+                    },
+                    {
+                        "message": "Install a different version of the mod 'Fabric API'."
                     }
                 ]
             },
             {
-                "message": "The mod 'Fabric Command API (v2)' is missing the required mod 'Minecraft'.",
+                "message": "The mod 'Fabric Command API (v2)' is not compatible with the Minecraft version 1.18.2.",
                 "counter": 1,
                 "entry": {
                     "level": 3,
@@ -265,7 +268,10 @@
                 },
                 "solutions": [
                     {
-                        "message": "Install the mod 'Minecraft' with version >=1.19-alpha.22.11.a, <1.20-."
+                        "message": "Install the version '>=1.19-alpha.22.11.a, <1.20-' of your server software."
+                    },
+                    {
+                        "message": "Install a different version of the mod 'Fabric Command API (v2)'."
                     }
                 ]
             }

--- a/test/tests/Logs/AutoLogsTest.php
+++ b/test/tests/Logs/AutoLogsTest.php
@@ -968,6 +968,16 @@ class AutoLogsTest extends \PHPUnit\Framework\TestCase
      * @return void
      * @throws Exception
      */
+    public function test_fabric_incompatible_minecraft_version(): void
+    {
+        $log = new TestLog('Vanilla/Fabric/fabric-incompatible-minecraft-version.log');
+        $this->assertStringEqualsFile($log->getExpectedPath(), $log->getOutput(), $log->getLogPath());
+    }
+
+    /**
+     * @return void
+     * @throws Exception
+     */
     public function test_fabric_incompatible_mods(): void
     {
         $log = new TestLog('Vanilla/Fabric/fabric-incompatible-mods.log');


### PR DESCRIPTION
Fabric always resolves dependencies for mods in the same way, regardless of whether the dependency is for a mod, a Minecraft version, or a Java version.

This results in strange error messages such as:

```
Mod 'Fabric API' (fabric-api) 0.141.3+1.21.11 requires any version between 1.21.11- (inclusive) and 1.21.12- (exclusive) of 'Minecraft' (minecraft), but only the wrong version is present: 1.16.5!
```

And we recommend the solution:
```
Install the mod 'Minecraft' with version >=1.21.11-, <1.21.12-.
```

This may confuse some users.
That is why I have now added this FabricModIncompatibleMinecraftVersionProblem.
This explicitly intercepts the error message with the name `'Minecraft' (minecraft)`. 

This results in the problem:
```
The mod 'Fabric API' is not compatible with the Minecraft version 1.16.5.
```

And the following two solutions are suggested:
1. **ServerInstallDifferentVersionSolution** `Install the version '>=1.19-alpha.22.18.a, <1.20-' of your server software.`
2. **ModInstallDifferentVersionSolution** `Install a different version of the mod 'Fabric API'.`
